### PR TITLE
Fix empty search params issue on tickets page pagination

### DIFF
--- a/client/src/pages/tickets/TicketDisplay.tsx
+++ b/client/src/pages/tickets/TicketDisplay.tsx
@@ -64,7 +64,7 @@ export const TicketDisplay = () => {
 
 	const withUrlParams = (pageUrl: string) => {
 		Object.keys(defaultForm).forEach((key) => {
-			pageUrl += `&${key}=${searchParams.get(key)}`
+			pageUrl += `&${key}=${searchParams.get(key) ?? ""}`
 		})
 		return pageUrl
 	}


### PR DESCRIPTION
fixed issue where the search params would be `null` instead of empty string when clicking on the pagination arrow buttons.