### PR TITLE
Styling Change on Progress Bar and Percentage Edits

### DIFF
--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -62,7 +62,7 @@ export const EditTicketForm = ({isModal, ticket, statusesToDisplay}: Props) => {
 		{ticketId: currentTicketId, params: {page: linkedTicketPage, isEpic: false}} : skipToken
 	)
 	const { data: epicTicketRelationships, isLoading: isEpicTicketRelationshipsLoading } = useGetTicketRelationshipsQuery(currentTicketId ? 
-		{ticketId: currentTicketId, params: {page: epicTicketPage, isEpic: true}} : skipToken
+		{ticketId: currentTicketId, params: {page: epicTicketPage, includeEpicPercentageCompletion: true, isEpic: true}} : skipToken
 	)
 	const [ updateTicket, {isLoading: isUpdateTicketLoading, error: isUpdateTicketError} ] = useUpdateTicketMutation() 
 	const [ bulkEditTicketAssignees ] = useBulkEditTicketAssigneesMutation()
@@ -415,20 +415,21 @@ export const EditTicketForm = ({isModal, ticket, statusesToDisplay}: Props) => {
 						<div className = "tw-flex tw-flex-col tw-gap-y-2">
 							{ticket?.ticketTypeId === epicTicketType?.id ? (
 								<>
-									<strong>Epic Tickets</strong>
-									<LinkedTicketForm isModal={isModal} currentTicketId={currentTicketId} isEpicParent={true} showAddLinkedIssue={showAddToEpic} setShowAddLinkedIssue={setShowAddToEpic} ticketRelationships={epicTicketRelationships?.data?.length ? epicTicketRelationships.data : []}/>
-									<PaginationRow
-										showNumResults={false}
-										showPageNums={false}
-										setPage={(page: number) => { setEpicTicketPage(page)}}	
-										paginationData={epicTicketRelationships?.pagination}
-										currentPage={epicTicketPage}
-									/>
+									<div className = "tw-flex tw-flex-row tw-justify-between">
+										<strong>Epic Tickets</strong>
+										<PaginationRow
+											showNumResults={false}
+											showPageNums={false}
+											setPage={(page: number) => { setEpicTicketPage(page)}}	
+											paginationData={epicTicketRelationships?.pagination}
+											currentPage={epicTicketPage}
+										/>
+									</div>
+									<LinkedTicketForm percentageCompleted={epicTicketRelationships?.additional?.percentageCompleted} isModal={isModal} currentTicketId={currentTicketId} isEpicParent={true} showAddLinkedIssue={showAddToEpic} setShowAddLinkedIssue={setShowAddToEpic} ticketRelationships={epicTicketRelationships?.data?.length ? epicTicketRelationships.data : []}/>
 								</>
 							) : null
 							}
 							<strong>Linked Issues</strong>	
-							<LinkedTicketForm currentTicketId={currentTicketId} showAddLinkedIssue={showAddLinkedIssue} setShowAddLinkedIssue={setShowAddLinkedIssue} ticketRelationships={ticketRelationships?.data?.length ? ticketRelationships.data : []}/>
 							<PaginationRow
 								showNumResults={false}
 								showPageNums={false}
@@ -436,6 +437,7 @@ export const EditTicketForm = ({isModal, ticket, statusesToDisplay}: Props) => {
 								paginationData={ticketRelationships?.pagination}
 								currentPage={linkedTicketPage}
 							/>
+							<LinkedTicketForm currentTicketId={currentTicketId} showAddLinkedIssue={showAddLinkedIssue} setShowAddLinkedIssue={setShowAddLinkedIssue} ticketRelationships={ticketRelationships?.data?.length ? ticketRelationships.data : []}/>
 						</div> : null
 					) : <LoadingSpinner/>}
 				</div>

--- a/client/src/components/LinkedTicketForm.tsx
+++ b/client/src/components/LinkedTicketForm.tsx
@@ -37,9 +37,10 @@ type Props = {
 	setShowAddLinkedIssue: (val: boolean) => void
 	isEpicParent?: boolean
 	isModal?: boolean
+	percentageCompleted?: number
 }
 
-export const LinkedTicketForm = ({isModal, currentTicketId, isEpicParent, showAddLinkedIssue, setShowAddLinkedIssue, ticketRelationships}: Props) => {
+export const LinkedTicketForm = ({isModal, currentTicketId, isEpicParent, showAddLinkedIssue, setShowAddLinkedIssue, ticketRelationships, percentageCompleted}: Props) => {
 	const selectRef = useRef<SelectInstance<OptionType, false, GroupBase<OptionType>>>(null) 
 	const { showModal } = useAppSelector((state) => state.modal) 
 	const { showSecondaryModal } = useAppSelector((state) => state.secondaryModal)
@@ -73,20 +74,13 @@ export const LinkedTicketForm = ({isModal, currentTicketId, isEpicParent, showAd
     	return acc
     }, {}) : {}
 
-    // calculate percentages for the epic progress bar based on the amount of statuses with the is_completed flag
 	const childEpicTickets = isEpicParent ? ticketRelationships?.filter((ticketRelationship) => {
     	return ticketRelationship.ticketRelationshipTypeId === epicTicketRelationshipType?.id && ticketRelationship.parentTicketId === currentTicketId 
     }) : []
-	const isCompletedChildTickets = isEpicParent ? childEpicTickets.filter((ticketRelationship) => {
-		const t = tickets?.data?.find((ticket) => ticket.id === ticketRelationship.childTicketId)
-		if (t){
-			return isCompletedStatusIds.includes(t.statusId)
-		}
-		return false
-	}) : []
+
 	const percentages: Array<ProgressBarPercentage> = isEpicParent ? [
-		{className: "tw-bg-primary", label: "Not Completed", value: ((childEpicTickets.length - isCompletedChildTickets.length) / childEpicTickets.length) * 100},
-		{className: "tw-bg-success", label: "Completed", value: (isCompletedChildTickets.length / childEpicTickets.length) * 100},
+		{className: "tw-bg-primary", label: "Completed", value: percentageCompleted ?? 0},
+		{className: "tw-bg-secondary", label: "Not Completed", value: 100 - (percentageCompleted ?? 0)},
 	] : []
 
 	const defaultForm = {

--- a/client/src/components/page-elements/ProgressBar.tsx
+++ b/client/src/components/page-elements/ProgressBar.tsx
@@ -7,11 +7,12 @@ type Props = {
 
 export const ProgressBar = ({percentages}: Props) => {
 	return (
-		<div className = "tw-w-full tw-flex tw-flex-row">
+		// overflow-hidden must be added so the colored bars do not overflow on top of the rounded borders
+		<div className = "tw-mb-4 tw-rounded-md tw-overflow-hidden tw-bg-gray-100 tw-w-full tw-h-2.5 tw-flex tw-flex-row">
 			{percentages.map((percentage: ProgressBarPercentage, i: number) => {
 				if (percentage.value > 0){
 					return (
-						<div style={{width: `${percentage.value}%`}} className = {`${i === 0 ? "tw-rounded-l-md" : "tw-rounded-r-md"} tw-text-white tw-text-center tw-h-8 ${percentage.className}`}></div>
+						<div style={{width: `${percentage.value}%`}} className = {`tw-text-white tw-text-center ${percentage.className}`}></div>
 					)
 				}
 			})}	

--- a/client/src/types/common.ts
+++ b/client/src/types/common.ts
@@ -115,6 +115,7 @@ export interface IPagination {
 export interface ListResponse<T> {
 	pagination: IPagination
 	data: Array<T>
+	additional?: Record<string, any>
 }
 
 export interface OptionType {


### PR DESCRIPTION
* rounded the progress bar edges
* Moved the pagination arrow to the top to align with the "Epic Tickets" header
* change the percentage such that it calculates the percentage of all completed child epic tickets, rather than only the ones that are shown on each page. In order to do this, added an `additional` attribute to the response that contains a `percentageCompleted` attribute for the `tickets/relationship` request. 


https://github.com/user-attachments/assets/b6a7b4bc-973d-4569-9ee1-27debc730899

