### PR TITLE
Switching Organizations

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -1,17 +1,78 @@
-import React from "react"
+import React, {useState, useRef, useEffect} from "react"
+import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks"
 import "../styles/dashboard.css"
+import { useNavigate, Link } from "react-router-dom" 
+import { useGetUserOrganizationsQuery, useSwitchUserOrganizationMutation } from "../services/private/userProfile"
+import { Organization, Toast, OptionType } from "../types/common"
+import { setCredentials } from "../slices/authSlice"
+import { logout } from "../slices/authSlice" 
+import { privateApi } from "../services/private" 
+import { addToast } from "../slices/toastSlice"
+import { v4 as uuidv4 } from "uuid" 
+import { AsyncSelect } from "./AsyncSelect"
+import { GroupBase, SelectInstance } from "react-select"
+import { USER_PROFILE_ORG_URL } from "../helpers/urls"
 
 export const Dashboard = () => {
+	const dispatch = useAppDispatch()
+	const navigate = useNavigate()
+	const [switchOrgId, setSwitchOrgId] = useState<number | null>(null)
+	const [cacheKey, setCacheKey] = useState(uuidv4())
+	const [switchUserOrganization, {isLoading, error}] = useSwitchUserOrganizationMutation()
+	const selectRef = useRef<SelectInstance<OptionType, false, GroupBase<OptionType>>>(null) 
+
+	const switchOrganization = async () => {
+		if (switchOrgId){
+			try {
+				const data = await switchUserOrganization({organizationId: switchOrgId}).unwrap()
+				dispatch(setCredentials(data))
+				
+				dispatch(privateApi.util.resetApiState())
+				dispatch(addToast({
+	    			id: uuidv4(),
+	    			type: "success",
+	    			animationType: "animation-in",
+	    			message: "Switched organization successfully!",
+	    		}))
+			}
+			catch (e){
+				dispatch(addToast({
+	    			id: uuidv4(),
+	    			type: "failure",
+	    			animationType: "animation-in",
+	    			message: "Failed to switch organization.",
+	    		}))
+			}
+		}
+		selectRef?.current?.clearValue()
+		setCacheKey(uuidv4())
+	}
+
 	return (
-		<div className = "dashboard-container">
-			<div>
+		<div className = "tw-flex tw-flex-row tw-justify-between tw-h-full tw-gap-x-2">
+			<div className = "tw-flex tw-flex-col tw-gap-y-2">
+				<h1>Organizations</h1>
+				<div>
+					<AsyncSelect 
+						ref={selectRef}
+						cacheKey={cacheKey} 
+						urlParams={{}} 
+						onSelect={(selectedOption: OptionType | null) => {
+							if (selectedOption){
+								setSwitchOrgId(Number(selectedOption.value))
+							}
+						}} 
+						endpoint={USER_PROFILE_ORG_URL} 
+						className = "tw-w-64"
+					/>
+				</div>
+				<button onClick={switchOrganization} className = "button">Switch Organization</button>
+			</div>
+			<div className = "tw-flex tw-flex-col tw-gap-y-2">
 				<h1>Assigned To Me</h1>
 			</div>
-			<div>
-				<h1>My Organization</h1>
-			</div>
-			<div>
-				<h1>Backlog</h1>
+			<div className = "tw-flex tw-flex-col tw-gap-y-2">
+				<h1>Watched Tickets</h1>
 			</div>
 		</div>
 	)	

--- a/client/src/components/page-elements/TopNav.tsx
+++ b/client/src/components/page-elements/TopNav.tsx
@@ -19,7 +19,6 @@ export const TopNav = ({isFetching}: Props) => {
 	const onLogout = () => {
 		dispatch(logout())
 		dispatch(privateApi.util.resetApiState())
-
 	}
 	return (
 		<div className = "tw-my-4 tw-w-full tw-flex tw-flex-row tw-justify-between tw-items-center">

--- a/client/src/helpers/urls.ts
+++ b/client/src/helpers/urls.ts
@@ -1,9 +1,11 @@
 export const API_VERSION = "api"
 export const BACKEND_BASE_URL = "http://localhost:8000"
 export const LOGIN_URL = `/${API_VERSION}/user/login`
+export const ORG_LOGIN_URL = `/${API_VERSION}/user/org-login`
 export const REGISTER_URL = `/${API_VERSION}/user/register`
 export const ORGANIZATION_URL = `/${API_VERSION}/organization`
-export const USER_PROFILE_URL = `/${API_VERSION}/user-profile/`
+export const USER_PROFILE_URL = `/${API_VERSION}/user-profile`
+export const USER_PROFILE_ORG_URL = `${USER_PROFILE_URL}/organization`
 export const USER_ROLE_URL = `/${API_VERSION}/user-role/`
 export const TICKET_URL = `/${API_VERSION}/ticket`
 export const BOARD_URL = `/${API_VERSION}/board`

--- a/client/src/layouts/ProtectedLayout.tsx
+++ b/client/src/layouts/ProtectedLayout.tsx
@@ -12,10 +12,12 @@ import { useGetTicketTypesQuery } from "../services/private/ticketType"
 import { useGetTicketRelationshipTypesQuery } from "../services/private/ticketRelationshipType"
 import { useGetPrioritiesQuery } from "../services/private/priority" 
 import { useGetUserRolesQuery } from "../services/private/userRole" 
+import { useGetOrganizationQuery } from "../services/public/organization"
 import { setUserProfile, setUserProfiles } from "../slices/userProfileSlice" 
 import { setUserRoles, setUserRoleLookup } from "../slices/userRoleSlice" 
 import { setStatuses } from "../slices/statusSlice" 
 import { setTicketTypes } from "../slices/ticketTypeSlice" 
+import { setOrganization } from "../slices/organizationSlice"
 import { setTicketRelationshipTypes } from "../slices/ticketRelationshipTypeSlice"
 import { setPriorities } from "../slices/prioritySlice"
 import { UserRole } from "../types/common" 
@@ -28,6 +30,7 @@ const ProtectedLayout = () => {
     const {data: statusData} = useGetStatusesQuery()
     const {data: ticketTypesData} = useGetTicketTypesQuery()
     const {data: ticketRelationshipTypeData} = useGetTicketRelationshipTypesQuery()
+    const {data: organizationsData } = useGetOrganizationQuery()
     const {data: priorityData} = useGetPrioritiesQuery()
     const {data: userRoleData } = useGetUserRolesQuery()
     const gutter = {margin: "var(--s-spacing)"}
@@ -62,8 +65,11 @@ const ProtectedLayout = () => {
 	        	}, {})
 	        	dispatch(setUserRoleLookup(userRoleLookup))
 	        }
+	        if (organizationsData){
+	        	dispatch(setOrganization({organizations: organizationsData}))	
+	        }
         }
-    }, [userProfileData, ticketTypesData, statusData, priorityData]);
+    }, [userProfileData, ticketTypesData, statusData, priorityData, organizationsData]);
 
 	if (!token){
 		return <Navigate replace to = {"/login"} state={{alert: "You have been logged out"}}/>

--- a/client/src/services/private/userProfile.ts
+++ b/client/src/services/private/userProfile.ts
@@ -1,8 +1,9 @@
 import { BaseQueryFn, FetchArgs, createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
 import { RootState } from "../../store" 
-import { BACKEND_BASE_URL, USER_PROFILE_URL } from "../../helpers/urls" 
-import { CustomError, UserProfile } from "../../types/common" 
+import { BACKEND_BASE_URL, USER_PROFILE_URL, ORG_LOGIN_URL } from "../../helpers/urls" 
+import { CustomError, ListResponse, Organization, UserProfile } from "../../types/common" 
 import { privateApi } from "../private"
+import { UserResponse } from "../public/auth"
 
 export const userProfileApi = privateApi.injectEndpoints({
 	overrideExisting: false,
@@ -18,8 +19,27 @@ export const userProfileApi = privateApi.injectEndpoints({
 				url: USER_PROFILE_URL,	
 				method: "GET",
 			})
-		})
+		}),
+		getUserOrganizations: builder.query<ListResponse<Organization>, Record<string, any>>({
+			query: (urlParams) => ({
+				url: `${USER_PROFILE_URL}/organization`,
+				method: "GET",
+				params: urlParams
+			})
+		}),
+		switchUserOrganization: builder.mutation<UserResponse, {organizationId: number}>({
+			query: ({organizationId}) => ({
+				url: ORG_LOGIN_URL,	
+				method: "POST",
+				body: {organization_id: organizationId}
+			})	
+		})	
 	}),
 })
 
-export const { useGetUserProfileQuery, useGetUserProfilesQuery } = userProfileApi 
+export const { 
+	useGetUserProfileQuery, 
+	useGetUserProfilesQuery, 
+	useGetUserOrganizationsQuery, 
+	useSwitchUserOrganizationMutation 
+} = userProfileApi 

--- a/client/src/services/private/userProfile.ts
+++ b/client/src/services/private/userProfile.ts
@@ -1,6 +1,6 @@
 import { BaseQueryFn, FetchArgs, createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
 import { RootState } from "../../store" 
-import { BACKEND_BASE_URL, USER_PROFILE_URL, ORG_LOGIN_URL } from "../../helpers/urls" 
+import { BACKEND_BASE_URL, USER_PROFILE_URL, USER_PROFILE_ORG_URL, ORG_LOGIN_URL } from "../../helpers/urls" 
 import { CustomError, ListResponse, Organization, UserProfile } from "../../types/common" 
 import { privateApi } from "../private"
 import { UserResponse } from "../public/auth"
@@ -22,7 +22,7 @@ export const userProfileApi = privateApi.injectEndpoints({
 		}),
 		getUserOrganizations: builder.query<ListResponse<Organization>, Record<string, any>>({
 			query: (urlParams) => ({
-				url: `${USER_PROFILE_URL}/organization`,
+				url: `${USER_PROFILE_ORG_URL}`,
 				method: "GET",
 				params: urlParams
 			})

--- a/server/routes/userProfile.js
+++ b/server/routes/userProfile.js
@@ -28,6 +28,26 @@ router.get("/me", async (req, res, next) => {
 	}
 })
 
+router.get("/organization", async (req, res, next) => {
+	try {
+		const {id: userId, organization: organizationId} = req.user
+		const organizations = await db("organization_user_roles")
+		.join("organizations", "organizations.id", "=", "organization_user_roles.organization_id")
+		.where("organization_user_roles.user_id", userId)
+		// exclude the currently logged in organization
+		.whereNot("organizations.id", organizationId)
+		.select(
+			"organizations.id as id",
+			"organizations.name",
+		).paginate({ perPage: 10, currentPage: req.query.page ? parseInt(req.query.page) : 1, isLengthAware: true});
+		res.json(organizations)
+	}	
+	catch (err) {
+		console.log(`Error while getting organizations: ${err.message}`)	
+		next(err)
+	}
+})
+
 router.get("/", async (req, res, next) => {
 	try {
 		// pulled from token middleware 


### PR DESCRIPTION
* On the home page dashboard, allow user to switch login to a different organization based on the organizations they've been added to on the `organization_user_roles` table.
* the `privateApi` state is reset upon switching organization, so data will be refreshed for that particular organization.

https://github.com/user-attachments/assets/bb6e9aa2-07aa-42f2-a6ef-75f2f87d13bf

