### PR TITLE
Convert `user-profile/` to pagination and async select for user profile select menus, added add watchers modal

### DIFF
--- a/client/src/components/AsyncSelect.tsx
+++ b/client/src/components/AsyncSelect.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback, useEffect } from "react"
-// import Select from "react-select"
 import { AsyncPaginate } from 'react-select-async-paginate';
 import { useLazyGenericFetchQuery } from "../services/private/generic"
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { ListResponse, OptionType } from "../types/common"
 import { OptionsOrGroups, GroupBase, SelectInstance } from "react-select"
 import { v4 as uuidv4 } from "uuid"
+import { SELECT_Z_INDEX } from "../helpers/constants"
 
 export interface LoadOptionsType {
 	options: ListResponse<any>
@@ -17,13 +17,17 @@ export interface LoadOptionsType {
 
 interface AsyncSelectProps {
 	endpoint: string
+	defaultValue?: OptionType 
+	clearable?: boolean
+	onBlur?: () => void
 	className?: string 
 	urlParams: Record<string, any>
 	cacheKey?: string
 	onSelect: (selectedOption: OptionType | null) => void
 }
 
-export const AsyncSelect = React.forwardRef<SelectInstance<OptionType, false, GroupBase<OptionType>>, AsyncSelectProps>(({ cacheKey, className, endpoint, onSelect, urlParams }, ref) => {
+export const AsyncSelect = React.forwardRef<SelectInstance<OptionType, false, GroupBase<OptionType>>, AsyncSelectProps>((
+	{ cacheKey, clearable, className, defaultValue, endpoint, onSelect, urlParams, onBlur }, ref) => {
 	const [searchTerm, setSearchTerm] = useState("")
 	const [ genericFetch ] = useLazyGenericFetchQuery()
 
@@ -68,10 +72,12 @@ export const AsyncSelect = React.forwardRef<SelectInstance<OptionType, false, Gr
 		<AsyncPaginate
 			selectRef={ref}
 			loadOptions={loadOptions}
+			defaultValue={defaultValue}
 			onInputChange={handleInputChange}
+			onBlur={onBlur}
 			additional={{page: 1}}
 			classNames={{
-			    control: (state) => className ?? "tw-w-full"
+			    control: (state) => `${SELECT_Z_INDEX} ${className}` ?? `tw-w-full ${SELECT_Z_INDEX}`
 			}}
 			styles={{
 			    control: (baseStyles, state) => ({
@@ -86,7 +92,7 @@ export const AsyncSelect = React.forwardRef<SelectInstance<OptionType, false, Gr
 			placeholder="Search"
 			// wait milliseconds amount after user stops typing before searching
 			debounceTimeout={300}
-			isClearable
+			isClearable={clearable ?? true}
 			cacheUniqs={[cacheKey ?? ""]}
 			menuShouldScrollIntoView={false}
 		/>

--- a/client/src/components/Dropdown.tsx
+++ b/client/src/components/Dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from "react"
+import { DROPDOWN_Z_INDEX } from "../helpers/constants"
 
 type Props = {
 	children: React.ReactNode
@@ -6,7 +7,7 @@ type Props = {
 
 export const Dropdown = React.forwardRef<HTMLDivElement, Props>(({children}, ref) => {
 	return (
-		<div ref = {ref} className="tw-origin-top-right tw-z-1000 tw-absolute tw-right-0 tw-mt-2 tw-w-56 tw-rounded-md tw-shadow-lg tw-bg-white tw-ring-1 tw-ring-black tw-ring-opacity-5">
+		<div ref = {ref} className={`${DROPDOWN_Z_INDEX} tw-origin-top-right tw-absolute tw-right-0 tw-mt-2 tw-w-56 tw-rounded-md tw-shadow-lg tw-bg-white tw-ring-1 tw-ring-black tw-ring-opacity-5`}>
 			<div className="tw-py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
 				{children}
 			</div>

--- a/client/src/components/EditTicketFormMenuDropdown.tsx
+++ b/client/src/components/EditTicketFormMenuDropdown.tsx
@@ -8,9 +8,10 @@ type Props = {
 	ticket: Ticket | null | undefined
 	boardId: string | number | null | undefined
 	statusesToDisplay: Array<Status>
+	closeDropdown: () => void
 }
 
-export const EditTicketFormMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({statusesToDisplay, boardId, ticket}: Props, ref) => {
+export const EditTicketFormMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({statusesToDisplay, boardId, ticket, closeDropdown}: Props, ref) => {
 	const { userProfile } = useAppSelector((state) => state.userProfile)
 	const { userRoleLookup } = useAppSelector((state) => state.userRole)
 	const { ticketTypes } = useAppSelector((state) => state.ticketType)
@@ -45,11 +46,14 @@ export const EditTicketFormMenuDropdown = React.forwardRef<HTMLDivElement, Props
 	}
 	return (
 		<Dropdown ref = {ref}>
-			<ul className = "tw-z-1000">
+			<ul>
 				{Object.keys(options).map((option) => (
 					<li
 						key={option}
-						onClick={() => options[option as keyof typeof options]?.()}
+						onClick={() => {
+							options[option as keyof typeof options]?.()
+							closeDropdown()
+						}}
 						className="tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
 						role="menuitem"
 					>

--- a/client/src/components/EditTicketFormToolbar.tsx
+++ b/client/src/components/EditTicketFormToolbar.tsx
@@ -69,7 +69,7 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 				</IconContext.Provider>
 				{
 					showWatchDropdown ? (
-						<WatchMenuDropdown ticketAssignee={ticketAssignee} ticketWatchers={ticketWatchers} ticket={ticket} ref = {watchMenuDropdownRef}/>
+						<WatchMenuDropdown closeDropdown={onClickWatchOutside} ticketAssignee={ticketAssignee} ticketWatchers={ticketWatchers} ticket={ticket} ref = {watchMenuDropdownRef}/>
 					) : null
 				}
 			</div>
@@ -95,7 +95,7 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 					}} className = "--transparent tw-p-0 hover:tw-opacity-60"><MenuIcon className = "tw-ml-3 --l-icon"/></button>
 					{
 						showDropdown ? (
-							<EditTicketFormMenuDropdown statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>
+							<EditTicketFormMenuDropdown closeDropdown={onClickOutside} statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>
 						) : null
 					}
 				</IconContext.Provider>

--- a/client/src/components/SecondaryModal.tsx
+++ b/client/src/components/SecondaryModal.tsx
@@ -9,6 +9,7 @@ import { DeleteTicketWarning } from "./secondary-modals/DeleteTicketWarning"
 import { AddToEpicFormModal } from "./secondary-modals/AddToEpicFormModal"
 import { AddTicketFormModal } from "./primary-modals/AddTicketFormModal"
 import { MoveTicketFormModal } from "./secondary-modals/MoveTicketFormModal"
+import { AddTicketWatchersModal } from "./secondary-modals/AddTicketWatchersModal"
 import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks" 
 import { SECONDARY_MODAL_Z_INDEX } from "../helpers/constants"
 
@@ -20,13 +21,15 @@ export const secondaryModalTypes = {
 	"DELETE_TICKET_WARNING": DeleteTicketWarning,
 	"ADD_TO_EPIC_FORM_MODAL": AddToEpicFormModal,
 	"MOVE_TICKET_FORM_MODAL": MoveTicketFormModal,
-	"CLONE_TICKET_FORM_MODAL": AddTicketFormModal
+	"CLONE_TICKET_FORM_MODAL": AddTicketFormModal,
+	"ADD_TICKET_WATCHERS_MODAL": AddTicketWatchersModal,
 }
 
 export const secondaryModalClassNames = {
 	"ADD_TO_EPIC_FORM_MODAL": avoidAsyncSelectMenuOverflow,
 	"MOVE_TICKET_FORM_MODAL": avoidAsyncSelectMenuOverflow,
 	"CLONE_TICKET_FORM_MODAL": avoidAsyncSelectMenuOverflow,
+	"ADD_TICKET_WATCHERS_MODAL": avoidAsyncSelectMenuOverflow,
 }
 
 export const SecondaryModal = () => {

--- a/client/src/components/WatchMenuDropdown.tsx
+++ b/client/src/components/WatchMenuDropdown.tsx
@@ -6,10 +6,6 @@ import { Toast, Ticket, Status, UserProfile } from "../types/common"
 import { CgProfile } from "react-icons/cg"
 import { IoMdEye as WatchIcon, IoMdEyeOff as WatchOffIcon } from "react-icons/io";
 import { 
-	useGetTicketAssigneesQuery, 
-	useGetTicketRelationshipsQuery, 
-	useGetTicketCommentsQuery,
-	useUpdateTicketMutation, 
 	useAddTicketAssigneeMutation,
 	useDeleteTicketAssigneeMutation, 
 } from "../services/private/ticket"
@@ -19,12 +15,13 @@ import { displayUser } from "../helpers/functions"
 import { FiPlus as PlusIcon } from "react-icons/fi";
 
 type Props = {
+	closeDropdown: () => void
 	ticket: Ticket | null | undefined
 	ticketAssignee: UserProfile | null | undefined
 	ticketWatchers: Array<UserProfile> | null | undefined
 }
 
-export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticket, ticketAssignee, ticketWatchers}: Props, ref) => {
+export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({closeDropdown, ticket, ticketAssignee, ticketWatchers}: Props, ref) => {
 	const { userProfile } = useAppSelector((state) => state.userProfile)
 	const { userRoleLookup } = useAppSelector((state) => state.userRole)
 	const { ticketTypes } = useAppSelector((state) => state.ticketType)
@@ -57,6 +54,12 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 				message: "Failed to add ticket watcher"
 			}))
 		}
+	}
+
+	const showAddWatchersModal = () => {
+		dispatch(toggleShowSecondaryModal(true))
+		dispatch(setSecondaryModalProps({ticketId: ticket?.id}))
+		dispatch(setSecondaryModalType("ADD_TICKET_WATCHERS_MODAL"))
 	}
 
 	const deleteTicketWatcher = async (ticketId: number | null | undefined, userId: number | null | undefined) => {
@@ -99,7 +102,7 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 	}
 	return (
 		<Dropdown ref = {ref}>
-			<ul className = "tw-z-1000">
+			<ul>
 				{Object.keys(options).map((option) => {
 					if (option === "Start Watching" || option === "Stop Watching"){
 						return (
@@ -144,9 +147,15 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 					onClick={() => options["Add Watchers"]?.()}
 					role = "menuitem"
 				>
-					<div className = "tw-flex tw-flex-row tw-items-center tw-gap-x-2">
-						<PlusIcon className = "tw-h-6 tw-w-6"/><p>Add Watchers</p>
-					</div>
+					<button onClick={() => {
+						showAddWatchersModal()
+						closeDropdown()
+					}}>
+						<div className = "tw-flex tw-flex-row tw-items-center tw-gap-x-2">
+							<PlusIcon className = "tw-h-6 tw-w-6"/>
+							<p>Add Watchers</p>
+						</div>
+					</button>
 				</li>
 			</ul>
 		</Dropdown>

--- a/client/src/components/WatchMenuDropdown.tsx
+++ b/client/src/components/WatchMenuDropdown.tsx
@@ -106,14 +106,14 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 							<li
 								key={option}
 								onClick={() => options[option as keyof typeof options]?.()}
-								className="tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
+								className="tw-border-b tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
 								role="menuitem"
 							>
-							<div className = "tw-flex tw-flex-row tw-gap-x-2">
-								{option === "Start Watching" ? 
-								<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>
-								: <div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchOffIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>}
-							</div>
+								<div className = "tw-flex tw-flex-row tw-gap-x-2">
+									{option === "Start Watching" ? 
+									<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>
+									: <div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchOffIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>}
+								</div>
 							</li>
 						)
 					}
@@ -122,7 +122,7 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 					className="tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
 					role = "menuitem"
 				>
-					<div className = "tw-border-t tw-border-b tw-flex tw-flex-col tw-gap-y-2 tw-py-1">
+					<div className = "tw-flex tw-flex-col tw-gap-y-2 tw-py-1">
 						<p>Watching This Issue</p>
 						<div className = "tw-flex tw-flex-col tw-gap-y-2">
 							{
@@ -140,7 +140,7 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({ticke
 					</div>
 				</li>
 				<li
-					className="tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
+					className="tw-border-t tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
 					onClick={() => options["Add Watchers"]?.()}
 					role = "menuitem"
 				>

--- a/client/src/components/secondary-modals/AddTicketWatchersModal.tsx
+++ b/client/src/components/secondary-modals/AddTicketWatchersModal.tsx
@@ -1,0 +1,100 @@
+import React, {useState} from "react"
+import { AsyncSelect } from "../AsyncSelect"
+import { useAppDispatch, useAppSelector } from "../../hooks/redux-hooks"
+import { useForm, Controller } from "react-hook-form"
+import { TICKET_ASSIGNEE_URL, USER_PROFILE_URL } from "../../helpers/urls" 
+import { addToast } from "../../slices/toastSlice"
+import { toggleShowSecondaryModal, setSecondaryModalType, setSecondaryModalProps } from "../../slices/secondaryModalSlice"
+import { 
+	useAddTicketAssigneeMutation,
+	useDeleteTicketAssigneeMutation, 
+} from "../../services/private/ticket"
+import { Toast } from "../../types/common"
+import { v4 as uuidv4 } from "uuid"
+
+type Props = {
+	ticketId: number | undefined
+}
+
+type FormValues = {
+	userId: number | string
+}
+
+export const AddTicketWatchersModal = ({ticketId}: Props) => {
+	const [cacheKey, setCacheKey] = useState(uuidv4())
+	const dispatch = useAppDispatch()
+	const [ addTicketAssignee, {isLoading: addTicketAssigneeLoading} ] = useAddTicketAssigneeMutation()
+	const [ deleteTicketAssignee, {isLoading: isDeleteTicketAssigneeLoading}] = useDeleteTicketAssigneeMutation()
+
+	const defaultForm = {
+		userId: "",
+	}
+
+	const registerOptions = {
+		userId: { required: "User is required"},
+    }
+
+    const [preloadedValues, setPreloadedValues] = useState<FormValues>(defaultForm)
+	const { register, control, handleSubmit, reset, setValue, watch, formState: {errors} } = useForm<FormValues>({
+		defaultValues: preloadedValues
+	})
+
+	const onSubmit = async (values: FormValues) => {
+		let defaultToast: Toast = {
+			id: uuidv4(),
+			message: "Something went wrong while linking ticket.",
+			animationType: "animation-in",
+			type: "failure"
+		}
+		if (ticketId){
+	    	try {
+		    	await addTicketAssignee({
+		    		ticketId: ticketId,
+		    		userIds: [Number(values.userId) ?? 0],
+		    		isWatcher: true
+			    	}).unwrap()
+			    	dispatch(addToast({
+			    		...defaultToast,
+			    		message: "Ticket watcher added successfully!",
+			    		type: "success"
+			    	}))
+		    	}
+		    	catch (e){
+		    		dispatch(addToast(defaultToast))
+		    	}
+	    	}
+    	else {
+    		dispatch(addToast(defaultToast))
+    	}
+    	dispatch(toggleShowSecondaryModal(false))
+    	dispatch(setSecondaryModalType(undefined))
+    	dispatch(setSecondaryModalProps({}))
+    	// flush cached options after submitting
+    	setCacheKey(uuidv4())
+	}
+
+	return (
+		<div className = "tw-flex tw-flex-col tw-gap-y-4">
+			<p className = "tw-font-bold">Add Watchers</p>		
+			<form className = "tw-flex tw-flex-col tw-gap-y-2" onSubmit={handleSubmit(onSubmit)}>
+				<Controller
+					name={"userId"}
+					control={control}
+	                render={({ field: { onChange, value, name, ref } }) => (
+	                	<AsyncSelect 
+		                	endpoint={USER_PROFILE_URL} 
+		                	cacheKey={cacheKey}
+		                	className={"tw-w-64"}
+		                	urlParams={{}} 
+		                	onSelect={(selectedOption: {label: string, value: string} | null) => {
+		                		onChange(selectedOption?.value ?? "") 	
+		                	}}
+		                />
+	                )}
+				/>
+				{/*<AsyncSelect endpoint={TICKET_URL} urlParams={{searchBy: "title", ticketType: epicTicketType?.id}} onSelect={handleSelect}/>*/}
+				<button className = "button">Submit</button>
+			</form>
+		</div>
+	)		
+}

--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -21,9 +21,13 @@ export const defaultStatusesToDisplay = [
 
 export const defaultRows = 4
 
-export const PRIMARY_MODAL_Z_INDEX = "tw-z-[100]"
+export const SELECT_Z_INDEX = "tw-z-0"
 
-export const SECONDARY_MODAL_Z_INDEX = "tw-z-[200]" 
+export const PRIMARY_MODAL_Z_INDEX = "tw-z-20"
+
+export const DROPDOWN_Z_INDEX = "tw-z-30"
+
+export const SECONDARY_MODAL_Z_INDEX = "tw-z-40" 
 
 export const TAG_TYPES = [
 	"Tickets",

--- a/client/src/layouts/ProtectedLayout.tsx
+++ b/client/src/layouts/ProtectedLayout.tsx
@@ -6,7 +6,7 @@ import { Modal } from "../components/Modal"
 import { SecondaryModal } from "../components/SecondaryModal" 
 import { TopNav } from "../components/page-elements/TopNav" 
 import { Footer } from "../components/page-elements/Footer"
-import { useGetUserProfileQuery, useGetUserProfilesQuery } from "../services/private/userProfile" 
+import { useGetUserProfileQuery } from "../services/private/userProfile" 
 import { useGetStatusesQuery } from "../services/private/status" 
 import { useGetTicketTypesQuery } from "../services/private/ticketType" 
 import { useGetTicketRelationshipTypesQuery } from "../services/private/ticketRelationshipType"
@@ -26,7 +26,6 @@ const ProtectedLayout = () => {
 	const token = useAppSelector((state) => state.auth.token)	
 	const dispatch = useAppDispatch()
     const {data: userProfileData, isFetching: isUserProfileFetching, isError: isUserProfileError } = useGetUserProfileQuery() 
-    const {data: userProfilesData, isFetching: isUserProfilesFetching, isError: isUserProfilesError } = useGetUserProfilesQuery() 
     const {data: statusData} = useGetStatusesQuery()
     const {data: ticketTypesData} = useGetTicketTypesQuery()
     const {data: ticketRelationshipTypeData} = useGetTicketRelationshipTypesQuery()
@@ -40,10 +39,6 @@ const ProtectedLayout = () => {
         if (token){
         	if (userProfileData){
 	        	dispatch(setUserProfile({userProfile: userProfileData}))
-	        }
-	        // get all user profiles
-        	if (userProfilesData){
-	        	dispatch(setUserProfiles({userProfiles: userProfilesData}))
 	        }
 	        if (ticketTypesData){
 	        	dispatch(setTicketTypes({ticketTypes: ticketTypesData}))	

--- a/client/src/services/private/userProfile.ts
+++ b/client/src/services/private/userProfile.ts
@@ -14,10 +14,17 @@ export const userProfileApi = privateApi.injectEndpoints({
 				method: "GET",
 			})	
 		}),
-		getUserProfiles: builder.query<Array<UserProfile>, void>({
-			query: () => ({
+		getUser: builder.query<UserProfile, number>({
+			query: (userId) => ({
+				url: `${USER_PROFILE_URL}/${userId}`,
+				method: "GET"
+			})
+		}),
+		getUserProfiles: builder.query<ListResponse<UserProfile>, Record<string, any>>({
+			query: (urlParams) => ({
 				url: USER_PROFILE_URL,	
 				method: "GET",
+				params: urlParams,
 			})
 		}),
 		getUserOrganizations: builder.query<ListResponse<Organization>, Record<string, any>>({
@@ -38,6 +45,7 @@ export const userProfileApi = privateApi.injectEndpoints({
 })
 
 export const { 
+	useGetUserQuery,
 	useGetUserProfileQuery, 
 	useGetUserProfilesQuery, 
 	useGetUserOrganizationsQuery, 

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -23,10 +23,10 @@ router.get("/", async (req, res, next) => {
 		const boards = await db("boards").where("organization_id", req.user.organization)
 		.modify((queryBuilder) => {
 			if (req.query.query){
-				queryBuilder.whereILike("name", req.query.query)
+				queryBuilder.whereILike("boards.name", `%${req.query.query}%`)
 			}
 			if (req.query.ignoreBoard){
-				queryBuilder.whereNot("id", req.query.ignoreBoard)
+				queryBuilder.whereNot("boards.id", req.query.ignoreBoard)
 			}
 			if (req.query.lastModified === "true"){
 				queryBuilder.leftJoin("tickets_to_boards","tickets_to_boards.board_id", "=", "boards.id")


### PR DESCRIPTION
* Converted the `user-profile` GET endpoint to use pagination. As a result, needed to convert all instances of user profile select menus to use `AsyncSelect`. 
* Fixed bug with the "Move Ticket" feature where the search queries were not being respected on the select menu.
* Added skeleton for the add watchers modal, but still need to call the backend endpoints
* Some small refactors with the `user-profile` endpoints, removing unnecessary join statements
* Refactored the `z-index` into constants