### PR TITLE
Convert back to queries for User Role Protection

### DIFF
--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -8,12 +8,16 @@ import { CgProfile } from "react-icons/cg";
 import { LoadingSpinner } from "./LoadingSpinner" 
 import { displayUser } from "../helpers/functions"
 import { Logo } from "../components/page-elements/Logo"
+import { useGetUserRolesQuery } from "../services/private/userRole"
+import { useGetUserProfileQuery } from "../services/private/userProfile"
 
 export const SideBar = () => {
 	const sideBar = useAppSelector((state) => state.nav)
-	const { userProfile } = useAppSelector((state) => state.userProfile)
-	const { userRoleLookup } = useAppSelector((state) => state.userRole)
-	const [ isLoading, setIsLoading ] = useState(true)
+	const { data: userRoles, isLoading: isUserRolesLoading } = useGetUserRolesQuery()
+	const { data: userProfile, isLoading: isUserProfileLoading } = useGetUserProfileQuery()
+	const [isLoading, setIsLoading] = useState(true)
+	const [isAdmin, setIsAdmin] = useState(false)
+	
 	const defaultLinks = [
 		{
 			pathname: "/", text: "Dashboard",
@@ -37,9 +41,10 @@ export const SideBar = () => {
 	const { pathname } = useLocation()
 
 	useEffect(() => {
-		if (userProfile && userRoleLookup){
-			const isAdmin = userProfile && userRoleLookup && userRoleLookup[userProfile.userRoleId] === "ADMIN"
-			setIsLoading(false)
+		if (!isUserProfileLoading && !isUserRolesLoading){
+			const admin = userRoles?.find((role) => role.name === "ADMIN")
+			const isAdmin = userProfile && admin?.id === userProfile.userRoleId
+			setIsAdmin(isAdmin ?? false)
 			setLinks([
 				...defaultLinks,
 				...(isAdmin ? [
@@ -52,8 +57,9 @@ export const SideBar = () => {
 				]: []),
 				...accountLink
 			])
+			setIsLoading(false)
 		}
-	}, [userProfile, userRoleLookup])
+	}, [isUserProfileLoading, isUserRolesLoading])
 
 	return (
 		<div className = {`sidebar --card-shadow --transition-transform ${sideBar.showSidebar ? "--translate-x-0" : "--translate-x-full-negative"}`}>

--- a/client/src/components/page-elements/TopNav.tsx
+++ b/client/src/components/page-elements/TopNav.tsx
@@ -15,7 +15,7 @@ export const TopNav = () => {
 	const [isLoading, setIsLoading] = useState(true)
 
 	useEffect(() => {
-		if (userProfile){
+		if (userProfile && Object.keys(userProfile).length){
 			setIsLoading(false)
 		}
 	}, [userProfile])

--- a/client/src/layouts/UserRoleProtectedLayout.tsx
+++ b/client/src/layouts/UserRoleProtectedLayout.tsx
@@ -4,28 +4,26 @@ import { Link, Outlet, Navigate, useParams } from "react-router-dom"
 import { LoadingSpinner } from "../components/LoadingSpinner"
 import { useGetUserRolesQuery } from "../services/private/userRole"
 import { useGetUserProfileQuery } from "../services/private/userProfile"
+import { UserRole } from "../types/common"
 
 const UserRoleProtectedLayout = () => {
-	const { userRoleLookup } = useAppSelector((state) => state.userRole)
-	const { userProfile } = useAppSelector((state) => state.userProfile)
+	const { data: userRoles, isLoading: isUserRolesLoading } = useGetUserRolesQuery()
+	const { data: userProfile, isLoading: isUserProfileLoading } = useGetUserProfileQuery()
 	const [isLoading, setIsLoading] = useState(true)
 	const [isAdmin, setIsAdmin] = useState(false)
 
 	useEffect(() => {
-		if (userRoleLookup && userProfile){
-			const isAdmin = userRoleLookup[userProfile.userRoleId] === "ADMIN"
-			setIsAdmin(isAdmin)
+		if (!isUserProfileLoading && !isUserRolesLoading){
+			const admin = userRoles?.find((role) => role.name === "ADMIN")
+			const isAdmin = userProfile && admin?.id === userProfile.userRoleId
+			setIsAdmin(isAdmin ?? false)
 			setIsLoading(false)
 		}
-	}, [userRoleLookup, userProfile])
-
-	if (!isLoading && !isAdmin){
-		return <Navigate replace to = {"/"} state={{alert: "You don't have permission to access this page"}}/>
+	}, [isUserProfileLoading, isUserRolesLoading])
+	if (isLoading){
+		return <></>
 	}
-	else if (!isLoading && isAdmin){
-		return <><Outlet/></>
-	}
-	return <></>
+	return !isAdmin ? <Navigate replace to = {"/"} state={{alert: "You don't have permission to access this page"}}/> : (<><Outlet/></>)
 }
 
 export default UserRoleProtectedLayout


### PR DESCRIPTION
* Turns out that relying on the state was flaky, so converting the user role protection back to performing two queries and pulling from that information for the most reliable info.