### PR TITLE
Remove scroll restoration from users page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -97,7 +97,6 @@ const router = createBrowserRouter([
 				{
 					path: USERS,
 					element: <>
-						<ScrollRestoration/>
 						<UsersDisplay/>
 					</>,
 				},

--- a/client/src/components/page-elements/BulkEditToolbar.tsx
+++ b/client/src/components/page-elements/BulkEditToolbar.tsx
@@ -20,7 +20,7 @@ export const BulkEditToolbar = ({itemIds, applyActionToAll, text, updateIds}: Pr
 				<IoMdClose className = "icon close-button"/>
 			</button>
 			<div><p className = "tw-font-bold tw-text-lg">{itemIds.length} Selected</p></div>
-			<div>
+			<div className = "tw-flex tw-flex-row tw-gap-x-2">
 				<button onClick={(e) => updateIds([])} className = "button !tw-bg-secondary">Unselect All</button>
 				<button onClick={(e) => applyActionToAll(itemIds)} className = "button">{text}</button>
 			</div>


### PR DESCRIPTION
* Remove the scroll restoration that causes the page to scroll back to the top each time on the users display page 