### PR TITLE
Fix /me query and phone number edit on organization page

### DIFF
--- a/client/src/layouts/ProtectedLayout.tsx
+++ b/client/src/layouts/ProtectedLayout.tsx
@@ -68,7 +68,7 @@ const ProtectedLayout = () => {
 	        	dispatch(setUserRoleLookup(userRoleLookup))
 	        }
         }
-    }, [userProfileData, ticketTypesData, statusData, priorityData]);
+    }, [token, userProfileData, ticketTypesData, statusData, priorityData]);
 
 	if (!token){
 		return <Navigate replace to = {"/login"} state={{alert: "You have been logged out"}}/>

--- a/client/src/pages/organization/OrganizationDisplay.tsx
+++ b/client/src/pages/organization/OrganizationDisplay.tsx
@@ -35,7 +35,7 @@ export const OrganizationDisplay = () => {
 								</div>
 								<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-start">
 									<FaLocationDot className = "--icon tw-mt-1"/>
-									<div>{`${organization?.address}, ${organization?.city}, ${organization.state} ${organization.zipcode}`}</div>	
+									<div>{`${organization?.address && organization?.city && organization?.state && organization?.zipcode ? `${organization?.address}, ${organization?.city}, ${organization?.state} ${organization?.zipcode}` : ""}`}</div>	
 								</div>
 								<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-start">
 									<FaPhone className = "--icon tw-mt-1"/>

--- a/server/routes/organization.js
+++ b/server/routes/organization.js
@@ -195,7 +195,7 @@ router.get("/:id", async (req, res, next) => {
 
 router.put("/:id", authenticateToken, authenticateUserRole(["ADMIN"]), validateUpdateOrganization, handleValidationResult, async (req, res, next) => {
 	try {
-		const { name, email, phoneNumber: phone_number, address, city, state, zipcode, industry } = req.body
+		const { name, email, phone_number, address, city, state, zipcode, industry } = req.body
 		await db("organizations").where("id", req.params.id).update({
 			name, email, phone_number, address, city, state, zipcode, industry	
 		})

--- a/server/routes/userProfile.js
+++ b/server/routes/userProfile.js
@@ -73,7 +73,8 @@ router.get("/me", async (req, res, next) => {
 		const userProfile = await db("organization_user_roles")
 			.join("users", "users.id", "=", "organization_user_roles.user_id")
 			.join("organizations", "organization_user_roles.organization_id", "=", "organizations.id")
-			.where("users.id", userId)
+			.where("organization_user_roles.user_id", userId)
+			.where("organization_user_roles.organization_id", organizationId)
 			.select(
 				"users.id as id", 
 				"users.first_name as firstName", 


### PR DESCRIPTION
* Fixed `/me` query to take into account user's organization so that when the user switches organizations, it will pull the right organization id.
* Phone number should now save on the organization page