### PR TITLE
Fixed lag after marking notifications as read

### DIFF
--- a/client/src/components/NotificationDropdown.tsx
+++ b/client/src/components/NotificationDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react"
 import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks"
 import { Dropdown } from "./Dropdown" 
 import { 
+	useUpdateNotificationMutation,
 	useBulkEditNotificationsMutation, 
 } from "../services/private/notification"
 import { addToast } from "../slices/toastSlice"
@@ -29,6 +30,7 @@ const ReadOnlyDropdownOption = ({children}: ReadOnlyDropdownOptionProps) => {
 export const NotificationDropdown = React.forwardRef<HTMLDivElement, Props>(({closeDropdown, notifications}: Props, ref) => {
 	const dispatch = useAppDispatch()
     const [ bulkEditNotifications, { error: bulkEditNotificationsError, isLoading: isBulkEditNotificationsLoading }] = useBulkEditNotificationsMutation()
+    const [ updateNotification, {error: updateNotificationError, isLoading: isUpdateNotificationLoading}] = useUpdateNotificationMutation()
 	const markMessagesRead = async (messages: Array<Notification>) => {
 		if (messages?.length){
 			try {
@@ -45,22 +47,40 @@ export const NotificationDropdown = React.forwardRef<HTMLDivElement, Props>(({cl
 		}		
 	}
 
+	const markMessageRead = async (message: Notification) => {
+		try {
+			await updateNotification({isRead: true, id: message.id}).unwrap()
+		}
+		catch {
+			dispatch(addToast({
+				id: uuidv4(),
+				message: "Failed to mark notification as read.",
+				animationType: "animation-in",
+				type: "failure"
+			}))	
+		}
+	}
+
 	return (
 		<Dropdown className = {"!tw-w-96"} ref = {ref}>
 			<ReadOnlyDropdownOption
 			>
 				<p className = "tw-font-bold">Notifications: </p>
-				<button onClick={() => {
+				<button onClick={async () => {
 					const unreadMessages = notifications?.filter(n => !n.isRead)
 					if (unreadMessages?.length){
-						markMessagesRead(unreadMessages)
+						await markMessagesRead(unreadMessages)
 					}
 				}} className = "button --secondary">Mark as Read</button>
 			</ReadOnlyDropdownOption>
 			{!notifications?.length ? <ReadOnlyDropdownOption><p>No Notifications Found</p></ReadOnlyDropdownOption> : null}
 			<ul>
 				{notifications?.map((notification) => (
-					<Link to = {notification.objectLink}>
+					<Link onClick={async () => {
+						if (!notification.isRead){
+							await markMessageRead(notification)}
+						}
+					} to = {notification.objectLink}>
 						<li
 							key={`notification-${notification.id}`}
 							className={`${!notification.isRead ? "tw-bg-gray-50" : ""} tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900`}

--- a/client/src/services/private/notification.ts
+++ b/client/src/services/private/notification.ts
@@ -28,7 +28,6 @@ export const notificationApi = privateApi.injectEndpoints({
 				method: "GET",
 				params: urlParams
 			}),
-			providesTags: ["Notifications"]
 		}),
 		addNotification: builder.mutation<{message: string}, NotificationRequest>({
 			query: ({notificationTypeId, ticketId, objectLink, recipientId, senderId}) => ({


### PR DESCRIPTION
* Fixed lag after marking notifications as read. The culprit was that the `pollNotifications` endpoint was providing tags for notifications, so once the notification was marked as read, it would have to wait until the `pollNotifications` endpoint came back with a response (either if the server times out after ~30 seconds or another notification comes in). 
* Removing the `providesTags` from `pollNotifications` fixed the issue.
* Also changed the individual notification reads to use the `PUT` endpoint instead of the `bulk-edit`
* On a side note, the database templates have to use triple curly braces on mustache.js (`{{{ }}}`) to escape quotations and other special characters. 