### PR TITLE
Migrate to Draft JS Plugins Library

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1460,6 +1460,25 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw=="
     },
+    "@draft-js-plugins/anchor": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/anchor/-/anchor-4.2.1.tgz",
+      "integrity": "sha512-Vp23TWTJMPImson5pQJHPYxCShGtcvf3e7Yofut6bt1IipLfAk2gspwLPVoSm1aL/bTKNlSBueRVq5dPUoWxDw==",
+      "requires": {
+        "@draft-js-plugins/utils": "^4.0.0",
+        "clsx": "^1.2.1",
+        "prepend-http": "3.0.1",
+        "prop-types": "^15.8.1",
+        "tlds": "^1.239.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
+      }
+    },
     "@draft-js-plugins/buttons": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@draft-js-plugins/buttons/-/buttons-4.3.3.tgz",
@@ -1482,6 +1501,40 @@
       "requires": {
         "immutable": "~3.7.4",
         "prop-types": "^15.8.1"
+      }
+    },
+    "@draft-js-plugins/inline-toolbar": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/inline-toolbar/-/inline-toolbar-4.2.1.tgz",
+      "integrity": "sha512-+LNhv9UkXhKybtUVHFMh7yvp44G3HKv8E5I6BLA3el+n67mrc3I4Frm/LE/wxAJC0tIrT2sjWvg8EFs3S9CRZA==",
+      "requires": {
+        "@draft-js-plugins/buttons": "^4.3.3",
+        "@draft-js-plugins/utils": "^4.2.1"
+      }
+    },
+    "@draft-js-plugins/linkify": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/linkify/-/linkify-4.2.2.tgz",
+      "integrity": "sha512-bUQKRSKUzV5LQP6MOwIPv+6U/dvfy0VjH2f46fFsCh5SbOqVBr157CGQrZ9qPrjZlBlAWCYS4nqPsluMzLXC1Q==",
+      "requires": {
+        "clsx": "^1.2.1",
+        "linkify-it": "^4.0.1",
+        "tlds": "^1.239.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        },
+        "linkify-it": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+          "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        }
       }
     },
     "@draft-js-plugins/static-toolbar": {
@@ -10573,6 +10626,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
+    "prepend-http": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz",
+      "integrity": "sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw=="
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -12397,6 +12455,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tlds": {
+      "version": "1.255.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.255.0.tgz",
+      "integrity": "sha512-tcwMRIioTcF/FcxLev8MJWxCp+GUALRhFEqbDoZrnowmKSGqPrl5pqS+Sut2m8BgJ6S4FExCSSpGffZ0Tks6Aw=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@draft-js-plugins/anchor": "^4.2.1",
     "@draft-js-plugins/editor": "^4.1.4",
+    "@draft-js-plugins/inline-toolbar": "^4.2.1",
+    "@draft-js-plugins/linkify": "^4.2.2",
     "@draft-js-plugins/static-toolbar": "^4.1.4",
     "@reduxjs/toolkit": "^2.2.1",
     "@testing-library/jest-dom": "^5.17.0",

--- a/client/src/components/AddTicketForm.tsx
+++ b/client/src/components/AddTicketForm.tsx
@@ -83,7 +83,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 
 	const registerOptions = {
 	    name: { required: "Name is required" },
-		description: textAreaValidation(),
+		description: textAreaValidation("Description"),
 	    priorityId: { required: "Priority is required"},
 	    statusId: { required: "Status is required"},
 	    ticketTypeId: { required: "Ticket Type is required"},

--- a/client/src/components/AddTicketForm.tsx
+++ b/client/src/components/AddTicketForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks"
 import { selectCurrentTicketId } from "../slices/boardSlice"
 import { toggleShowModal } from "../slices/modalSlice" 
-import { Controller, useForm } from "react-hook-form"
+import { Controller, useForm, FormProvider } from "react-hook-form"
 import { v4 as uuidv4 } from "uuid" 
 import type { UserProfile, Status, Ticket, TicketType, Priority } from "../types/common"
 import { useAddBoardTicketsMutation, useDeleteBoardTicketMutation } from "../services/private/board"
@@ -141,87 +141,88 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 
 	return (
 		<div className = "tw-flex tw-flex-col tw-w-[500px]">
-			<form>
-				<div className = "tw-flex tw-flex-col tw-gap-y-2">
-					<div>
-						<label className = "label" htmlFor="ticket-name">Name</label>
-						<input className = "tw-w-full" id = "ticket-name" type = "text"
-						{...register("name", registerOptions.name)}
-						/>
-				        {errors?.name && <small className = "--text-alert">{errors.name.message}</small>}
-					</div>
-					<div>
-						<label className = "label" htmlFor = "ticket-status">Status</label>
-						<select className = "tw-w-full" id = "ticket-status" {...register("statusId", registerOptions.statusId)}>
-							{statusesToDisplay?.map((status: Status) => {
-								return <option key = {status.id} value = {status.id}>{status.name}</option>
-							})}
-						</select>	
-				        {errors?.statusId && <small className = "--text-alert">{errors.statusId.message}</small>}
-					</div>
-					<div>
-						<label className = "label" htmlFor = "ticket-description">Description</label>
-						<TextArea
-							registerField={"description"}
-							registerOptions={registerOptions.description}
-							control={control}
-						/>
-				        {errors?.description && <small className = "--text-alert">{errors.description.message}</small>}
-				    </div>
-				    <div>
-						<label className = "label" htmlFor = "ticket-assignee">Assignee</label>
-						<Controller
-							name={"userId"}
-							control={control}
-			                render={({ field: { onChange, value, name, ref } }) => (
-		                	<AsyncSelect 
-			                	endpoint={USER_PROFILE_URL} 
-			                	urlParams={{forSelect: true}} 
-			                	className={"tw-w-full"}
-			                	onSelect={(selectedOption: {label: string, value: string} | null) => {
-			                		onChange(selectedOption?.value ?? "") 	
-			                	}}
-			                />
-		                )}
-						/>
-				        {errors?.userId && <small className = "--text-alert">{errors.userId.message}</small>}
-					</div>
-					<div>
-						<label className = "label" htmlFor = "ticket-priority">Priority</label>
-						<select className = "tw-w-full" id = "ticket-priority" {...register("priorityId", registerOptions.priorityId)}>
-							{priorities.map((priority: Priority) => {
-								return <option key = {priority.id} value = {priority.id}>{priority.name}</option>
-							})}
-						</select>
-				        {errors?.priorityId && <small className = "--text-alert">{errors.priorityId.message}</small>}
-					</div>
-					<div className = "tw-space-y-2">
-						<>
-							<label className = "label" htmlFor = "ticket-type">Ticket Type</label>
-							<select className = "tw-w-full" id = "ticket-type" {...register("ticketTypeId", registerOptions.ticketTypeId)}>
-								{ticketTypes.map((ticketType: TicketType) => {
-									return <option key = {ticketType.id} value = {ticketType.id}>{ticketType.name}</option>
+			<FormProvider {...methods}>
+				<form>
+					<div className = "tw-flex tw-flex-col tw-gap-y-2">
+						<div>
+							<label className = "label" htmlFor="ticket-name">Name</label>
+							<input className = "tw-w-full" id = "ticket-name" type = "text"
+							{...register("name", registerOptions.name)}
+							/>
+					        {errors?.name && <small className = "--text-alert">{errors.name.message}</small>}
+						</div>
+						<div>
+							<label className = "label" htmlFor = "ticket-status">Status</label>
+							<select className = "tw-w-full" id = "ticket-status" {...register("statusId", registerOptions.statusId)}>
+								{statusesToDisplay?.map((status: Status) => {
+									return <option key = {status.id} value = {status.id}>{status.name}</option>
+								})}
+							</select>	
+					        {errors?.statusId && <small className = "--text-alert">{errors.statusId.message}</small>}
+						</div>
+						<div>
+							<label className = "label" htmlFor = "ticket-description">Description</label>
+							<TextArea
+								registerField={"description"}
+								registerOptions={registerOptions.description}
+							/>
+					        {errors?.description && <small className = "--text-alert">{errors.description.message}</small>}
+					    </div>
+					    <div>
+							<label className = "label" htmlFor = "ticket-assignee">Assignee</label>
+							<Controller
+								name={"userId"}
+								control={control}
+				                render={({ field: { onChange, value, name, ref } }) => (
+			                	<AsyncSelect 
+				                	endpoint={USER_PROFILE_URL} 
+				                	urlParams={{forSelect: true}} 
+				                	className={"tw-w-full"}
+				                	onSelect={(selectedOption: {label: string, value: string} | null) => {
+				                		onChange(selectedOption?.value ?? "") 	
+				                	}}
+				                />
+			                )}
+							/>
+					        {errors?.userId && <small className = "--text-alert">{errors.userId.message}</small>}
+						</div>
+						<div>
+							<label className = "label" htmlFor = "ticket-priority">Priority</label>
+							<select className = "tw-w-full" id = "ticket-priority" {...register("priorityId", registerOptions.priorityId)}>
+								{priorities.map((priority: Priority) => {
+									return <option key = {priority.id} value = {priority.id}>{priority.name}</option>
 								})}
 							</select>
-						</>
-				        {errors?.ticketTypeId && <small className = "--text-alert">{errors.ticketTypeId.message}</small>}
-				        {
-				        	watch("ticketTypeId") == epicTicketType?.id ? (
-						        <div className = "tw-flex tw-flex tw-items-center tw-gap-x-2">
-							        <IconContext.Provider value={{color: "var(--bs-warning)"}}>
-										<WarningIcon className = "tw-h-6 tw-w-6"/>
-									</IconContext.Provider>
-									<span className = "tw-font-bold">If the ticket type is "Epic", it cannot changed once saved.</span>
-								</div>
-				        	) : null
-				        }
+					        {errors?.priorityId && <small className = "--text-alert">{errors.priorityId.message}</small>}
+						</div>
+						<div className = "tw-space-y-2">
+							<>
+								<label className = "label" htmlFor = "ticket-type">Ticket Type</label>
+								<select className = "tw-w-full" id = "ticket-type" {...register("ticketTypeId", registerOptions.ticketTypeId)}>
+									{ticketTypes.map((ticketType: TicketType) => {
+										return <option key = {ticketType.id} value = {ticketType.id}>{ticketType.name}</option>
+									})}
+								</select>
+							</>
+					        {errors?.ticketTypeId && <small className = "--text-alert">{errors.ticketTypeId.message}</small>}
+					        {
+					        	watch("ticketTypeId") == epicTicketType?.id ? (
+							        <div className = "tw-flex tw-flex tw-items-center tw-gap-x-2">
+								        <IconContext.Provider value={{color: "var(--bs-warning)"}}>
+											<WarningIcon className = "tw-h-6 tw-w-6"/>
+										</IconContext.Provider>
+										<span className = "tw-font-bold">If the ticket type is "Epic", it cannot changed once saved.</span>
+									</div>
+					        	) : null
+					        }
+						</div>
+						
+						<div>
+							<LoadingButton onClick={handleSubmit(onSubmit)} className = "button" text={"Submit"}></LoadingButton>
+						</div>
 					</div>
-					
-					<div>
-						<LoadingButton onClick={handleSubmit(onSubmit)} className = "button" text={"Submit"}></LoadingButton>
-					</div>
-				</div>
-			</form>
+				</form>
+			</FormProvider>
 		</div>
 	)	
 }

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -45,6 +45,7 @@ import {
 	convertEditorStateToHTML, 
 	convertJSONToEditorState 
 } from "./page-elements/TextArea"
+import { TextAreaDisplay } from "./page-elements/TextAreaDisplay"
 import { Avatar } from "./page-elements/Avatar"
 
 
@@ -283,7 +284,9 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									</div>
 								) : (
 									<>
-										<InlineEdit onSubmit = {async () => {
+										<InlineEdit 
+											isLoading={isUpdateTicketLoading}
+											onSubmit = {async () => {
 											await handleSubmit(onSubmit)()
 											if (!errors?.name){
 												toggleFieldVisibility("name", false)
@@ -323,17 +326,18 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									) : null
 								}
 							</div>
-							<div className = "">
+							<div className = "tw-flex tw-flex-col tw-gap-y-2">
 								<strong>Description</strong>
 								<>
 									{
 										!editFieldVisibility.description ? (
 											<div onClick = {(e) => toggleFieldVisibility("description", true)} className = "hover:tw-opacity-60 tw-cursor-pointer">
-												<div className = "textarea-ignore-global" dangerouslySetInnerHTML={{ __html: convertEditorStateToHTML(watch("description")) }}></div>
+												<TextAreaDisplay rawHTMLString={convertEditorStateToHTML(watch("description"))}/>
 											</div>
 										) : (
 											<div className = "tw-flex tw-flex-col tw-gap-y-2">
 												<InlineEdit 
+													isLoading={isUpdateTicketLoading}
 													onSubmit={async () => {
 														await handleSubmit(onSubmit)()
 														if (!errors?.description){

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -113,7 +113,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	const { register , control, handleSubmit, reset, resetField, setValue, watch, formState: {errors} } = methods
 	const registerOptions = {
 	    name: { required: "Name is required" },
-    	description: textAreaValidation(),
+    	description: textAreaValidation("Description"),
 	    priorityId: { required: "Priority is required"},
 	    statusId: { required: "Status is required"},
 	    ticketTypeId: { required: "Ticket Type is required"},

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -48,7 +48,6 @@ import {
 import { TextAreaDisplay } from "./page-elements/TextAreaDisplay"
 import { Avatar } from "./page-elements/Avatar"
 
-
 type EditFieldVisibility = {
 	[key: string]: boolean
 }

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { useFormContext } from "react-hook-form"
+import { Controller, useForm, FormProvider, useFormContext } from "react-hook-form"
 import { TextArea } from "./page-elements/TextArea"
 import { LoadingButton } from "./page-elements/LoadingButton"
 
@@ -15,7 +15,8 @@ type Props = {
 }
 
 export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customReset, registerField, registerOptions}: Props) => {
-	const { control, handleSubmit, register, resetField, setValue } = useFormContext()
+	const methods = useFormContext()
+	const { control, handleSubmit, register, resetField, setValue } = methods
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
 		if (e.key === "Escape"){
@@ -42,11 +43,12 @@ export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customRe
 			break
 		case "textarea":
 			element = (
-				<TextArea
-					control={control}
-					registerField={registerField}
-					registerOptions={registerOptions}
-				/>
+				<FormProvider {...methods}>
+					<TextArea
+						registerField={registerField}
+						registerOptions={registerOptions}
+					/>
+				</FormProvider>
 			)
 			break
 		default:

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { TextArea } from "./page-elements/TextArea"
+import { LoadingButton } from "./page-elements/LoadingButton"
 
 type Props = {
 	type: string
@@ -10,9 +11,10 @@ type Props = {
 	customReset?: () => void
 	registerField: string
 	registerOptions: Record<string, any>
+	isLoading?: boolean
 }
 
-export const InlineEdit = ({type, value, onSubmit, onCancel, customReset, registerField, registerOptions}: Props) => {
+export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customReset, registerField, registerOptions}: Props) => {
 	const { control, handleSubmit, register, resetField, setValue } = useFormContext()
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -64,10 +66,10 @@ export const InlineEdit = ({type, value, onSubmit, onCancel, customReset, regist
 				{element}
 			</div>
 			<div className = "tw-flex tw-flex-row tw-gap-x-2">
-				<button type = "button" className = "button" onClick={(e) => {
+				<LoadingButton isLoading={isLoading} className = "button" text={"Save"} onClick={(e) => {
 					e.preventDefault()
 					onSubmit()
-				}}>Save</button>
+				}}></LoadingButton>
 				<button type = "button" onClick={(e) => {
 					e.preventDefault()
 					customReset ? customReset() : resetField(registerField)

--- a/client/src/components/TicketCommentForm.tsx
+++ b/client/src/components/TicketCommentForm.tsx
@@ -27,6 +27,7 @@ import {
 	convertJSONToEditorState 
 } from "./page-elements/TextArea"
 import { Avatar } from "./page-elements/Avatar"
+import { TextAreaDisplay } from "./page-elements/TextAreaDisplay"
 
 type CommentFormValues = {
 	id: number
@@ -244,7 +245,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 										/>
 									</FormProvider>
 								) : (
-									<div className = "textarea-ignore-global" dangerouslySetInnerHTML={{ __html: convertEditorStateToHTML(convertJSONToEditorState(comment.comment)) }}></div>
+									<TextAreaDisplay rawHTMLString={convertEditorStateToHTML(convertJSONToEditorState(comment.comment))}/>
 								)}
 								{comment.userId === userProfile?.id && !showAddCommentForm && !showEditCommentId ? (
 									<div className = "tw-flex tw-flex-row tw-gap-x-2">

--- a/client/src/components/TicketCommentForm.tsx
+++ b/client/src/components/TicketCommentForm.tsx
@@ -93,7 +93,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 	})
 	const { register , handleSubmit, reset, setValue, watch, formState: {errors} } = methods
 	const registerOptions = {
-	    comment: textAreaValidation(),
+	    comment: textAreaValidation("Comment"),
     }
 	/* 
 	Because only one comment can exist on the form at once, the 

--- a/client/src/components/TicketCommentForm.tsx
+++ b/client/src/components/TicketCommentForm.tsx
@@ -44,14 +44,16 @@ type CommentFieldProps = {
 }
 
 export const CommentField = ({isLoading, registerOptions, onSubmit, onCancel}: CommentFieldProps) => {
-	const { handleSubmit, control, register, resetField, setValue, formState: {errors} } = useFormContext<CommentFormValues>()
+	const methods = useFormContext<CommentFormValues>()
+	const { handleSubmit, control, register, resetField, setValue, formState: {errors} } = methods
 	return (
 		<form className = "tw-flex tw-flex-col tw-gap-y-2 tw-w-full">
-			<TextArea
-				registerField={"comment"}
-				registerOptions={registerOptions}
-				control={control}
-			/>
+			<FormProvider {...methods}>
+				<TextArea
+					registerField={"comment"}
+					registerOptions={registerOptions}
+				/>
+			</FormProvider>
 	        {errors?.comment && <small className = "--text-alert">{errors.comment.message}</small>}
 			<div className = "tw-flex tw-flex-row tw-gap-x-2">
 				<LoadingButton isLoading={isLoading} className = "button" text={"Save"} onClick={onSubmit}></LoadingButton>

--- a/client/src/components/page-elements/TextArea.tsx
+++ b/client/src/components/page-elements/TextArea.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { Controller, Control, FieldValues } from "react-hook-form"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
-import { Editor } from "react-draft-wysiwyg"
+// import { Editor } from "react-draft-wysiwyg"
+import Editor from "@draft-js-plugins/editor"
+import '@draft-js-plugins/static-toolbar/lib/plugin.css'
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
 import { stateToHTML } from 'draft-js-export-html'; 
 
@@ -90,10 +92,10 @@ export const TextArea = ({registerField, registerOptions, toolbarOptions, contro
 			render={({field: {value, onChange}}) => (
 				<Editor 
 					editorState={value} 
-					onEditorStateChange={onChange}
-					wrapperClassName="tw-border tw-p-1 tw-border-gray-300"
-				    editorClassName="tw-p-1"
-				    toolbar={toolbarOptions ?? defaultToolbarOptions}
+					onChange={onChange}
+					// wrapperClassName="tw-border tw-p-1 tw-border-gray-300"
+				    // editorClassName="tw-p-1"
+				    // toolbar={toolbarOptions ?? defaultToolbarOptions}
 				/>
 			)}
 		/>

--- a/client/src/components/page-elements/TextArea.tsx
+++ b/client/src/components/page-elements/TextArea.tsx
@@ -3,9 +3,12 @@ import { Controller, Control, FieldValues } from "react-hook-form"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
 // import { Editor } from "react-draft-wysiwyg"
 import Editor from "@draft-js-plugins/editor"
+import createToolbarPlugin from "@draft-js-plugins/static-toolbar"
 import '@draft-js-plugins/static-toolbar/lib/plugin.css'
-import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
+import 'draft-js/dist/Draft.css';
+// import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
 import { stateToHTML } from 'draft-js-export-html'; 
+import "../../styles/textarea.css"
 
 
 type Props = {
@@ -65,6 +68,10 @@ export const convertEditorStateToHTML = (state: EditorState) => {
 	return stateToHTML(state.getCurrentContent(), stateToHTMLOptions())
 }
 
+const staticToolbarPlugin = createToolbarPlugin()
+const { Toolbar } = staticToolbarPlugin
+const plugins = [staticToolbarPlugin]
+
 export const TextArea = ({registerField, registerOptions, toolbarOptions, control}: Props) => {
 	const defaultToolbarOptions = {
 	    options: ['inline', 'blockType', 'list', 'link', 'emoji', 'image', 'remove', 'history'],
@@ -90,13 +97,17 @@ export const TextArea = ({registerField, registerOptions, toolbarOptions, contro
 			control={control}
 			rules={registerOptions}
 			render={({field: {value, onChange}}) => (
-				<Editor 
-					editorState={value} 
-					onChange={onChange}
-					// wrapperClassName="tw-border tw-p-1 tw-border-gray-300"
-				    // editorClassName="tw-p-1"
-				    // toolbar={toolbarOptions ?? defaultToolbarOptions}
-				/>
+				<div className = "__editor-block">
+					<Toolbar/>
+					<Editor 
+						editorState={value} 
+						onChange={onChange}
+						plugins={plugins}
+						// wrapperClassName="tw-border tw-p-1 tw-border-gray-300"
+					    // editorClassName="tw-p-1"
+					    // toolbar={toolbarOptions ?? defaultToolbarOptions}
+					/>
+				</div>
 			)}
 		/>
 	)

--- a/client/src/components/page-elements/TextArea.tsx
+++ b/client/src/components/page-elements/TextArea.tsx
@@ -1,12 +1,10 @@
 import React from "react"
 import { Controller, Control, FieldValues } from "react-hook-form"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
-// import { Editor } from "react-draft-wysiwyg"
 import Editor from "@draft-js-plugins/editor"
 import createToolbarPlugin, { Separator } from "@draft-js-plugins/static-toolbar"
 import '@draft-js-plugins/static-toolbar/lib/plugin.css'
 import 'draft-js/dist/Draft.css';
-// import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
 import { stateToHTML } from 'draft-js-export-html'; 
 import "../../styles/textarea.css"
 import {
@@ -83,24 +81,6 @@ const { Toolbar } = staticToolbarPlugin
 const plugins = [staticToolbarPlugin]
 
 export const TextArea = ({registerField, registerOptions, toolbarOptions, control}: Props) => {
-	const defaultToolbarOptions = {
-	    options: ['inline', 'blockType', 'list', 'link', 'emoji', 'image', 'remove', 'history'],
-	    inline: {
-	      inDropdown: false,
-	      options: ['bold', 'italic', 'underline', 'strikethrough', 'monospace'],
-	    },
-	    list: {
-	      inDropdown: true,
-	      options: ['unordered', 'ordered', 'indent', 'outdent'],
-	    },
-	    textAlign: {
-	      inDropdown: true,
-	      options: ['left', 'center', 'right', 'justify'],
-	    },
-	    link: {
-	    	defaultToolbarOptions: "_blank"
-	    },
-    }
 	return (
 		<Controller 
 			name={registerField} 	
@@ -129,9 +109,6 @@ export const TextArea = ({registerField, registerOptions, toolbarOptions, contro
 						editorState={value} 
 						onChange={onChange}
 						plugins={plugins}
-						// wrapperClassName="tw-border tw-p-1 tw-border-gray-300"
-					    // editorClassName="tw-p-1"
-					    // toolbar={toolbarOptions ?? defaultToolbarOptions}
 					/>
 				</div>
 			)}

--- a/client/src/components/page-elements/TextArea.tsx
+++ b/client/src/components/page-elements/TextArea.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
 import Editor from "@draft-js-plugins/editor"
-import { FormProvider, useFormContext } from "react-hook-form"
+import { Controller, FormProvider, useFormContext } from "react-hook-form"
 import createToolbarPlugin, { Separator } from "@draft-js-plugins/static-toolbar"
 import createLinkPlugin from "@draft-js-plugins/anchor"
 import createLinkifyPlugin from "@draft-js-plugins/linkify"
@@ -45,13 +45,13 @@ type OverrideOnOverrideContent = (
   content: React.ComponentType<OverrideContentProps> | undefined
 ) => void
 
-export const textAreaValidation = () => {
+export const textAreaValidation = (field: string) => {
 	return {
 		validate: {
 	    	// check if the rich text editor contains any text excluding whitespaces
 	        required: (value: EditorState) => {
 		        if (!value.getCurrentContent().hasText() && !(value.getCurrentContent().getPlainText().length > 0)){
-		        	return "Description is required"
+		        	return `${field} is required`
 		        } 	
 	        }
 		}
@@ -119,43 +119,55 @@ export const TextArea = ({registerField, registerOptions, toolbarOptions}: Props
 
 	return (
 		<div className = "__editor">
-			<Toolbar>
-			{
-				(externalProps) => (
-					<>
-						<BoldButton {...externalProps} />
-		                <ItalicButton {...externalProps} />
-		                <UnderlineButton {...externalProps} />
-		                <CodeButton {...externalProps} />
-		                <Separator/>
-		                <UnorderedListButton {...externalProps} />
-		                <OrderedListButton {...externalProps} />
-		                <BlockquoteButton {...externalProps} />
-		                <CodeBlockButton {...externalProps} />		
-					</>
-				)
-			}	
-			</Toolbar>
-			<Editor 
-				editorState={editorState} 
-				onChange={onChangeEditor}
-				plugins={plugins}
+			{/* Controller is still necessary for validation */}
+			<Controller
+				name={registerField} 	
+				control={control}
+				rules={registerOptions}
+				render={() => {
+					return (
+						<>
+							<Toolbar>
+							{
+								(externalProps) => (
+									<>
+										<BoldButton {...externalProps} />
+						                <ItalicButton {...externalProps} />
+						                <UnderlineButton {...externalProps} />
+						                <CodeButton {...externalProps} />
+						                <Separator/>
+						                <UnorderedListButton {...externalProps} />
+						                <OrderedListButton {...externalProps} />
+						                <BlockquoteButton {...externalProps} />
+						                <CodeBlockButton {...externalProps} />		
+									</>
+								)
+							}	
+							</Toolbar>
+							<Editor 
+								editorState={editorState} 
+								onChange={onChangeEditor}
+								plugins={plugins}
+							/>
+							<inlineToolbarPlugin.InlineToolbar>
+						    {
+						        (externalProps) => (
+									<>
+										<BoldButton {...externalProps} />
+										<ItalicButton {...externalProps} />
+										<UnderlineButton {...externalProps} />
+										<CodeButton {...externalProps} />
+										<linkPlugin.LinkButton {...externalProps} onOverrideContent={
+											externalProps.onOverrideContent as OverrideOnOverrideContent  
+										}/> 
+									</>
+						        )
+						    }
+						    </inlineToolbarPlugin.InlineToolbar>
+					    </>
+					)	
+				}}
 			/>
-			<inlineToolbarPlugin.InlineToolbar>
-		    {
-		        (externalProps) => (
-					<>
-						<BoldButton {...externalProps} />
-						<ItalicButton {...externalProps} />
-						<UnderlineButton {...externalProps} />
-						<CodeButton {...externalProps} />
-						<linkPlugin.LinkButton {...externalProps} onOverrideContent={
-							externalProps.onOverrideContent as OverrideOnOverrideContent  
-						}/> 
-					</>
-		        )
-		    }
-		    </inlineToolbarPlugin.InlineToolbar>
 		</div>
 	)
 }

--- a/client/src/components/page-elements/TextArea.tsx
+++ b/client/src/components/page-elements/TextArea.tsx
@@ -3,12 +3,22 @@ import { Controller, Control, FieldValues } from "react-hook-form"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
 // import { Editor } from "react-draft-wysiwyg"
 import Editor from "@draft-js-plugins/editor"
-import createToolbarPlugin from "@draft-js-plugins/static-toolbar"
+import createToolbarPlugin, { Separator } from "@draft-js-plugins/static-toolbar"
 import '@draft-js-plugins/static-toolbar/lib/plugin.css'
 import 'draft-js/dist/Draft.css';
 // import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
 import { stateToHTML } from 'draft-js-export-html'; 
 import "../../styles/textarea.css"
+import {
+	ItalicButton,
+	BoldButton,
+	UnderlineButton,
+	CodeButton,
+	UnorderedListButton,
+	OrderedListButton,
+	BlockquoteButton,
+	CodeBlockButton,
+} from "@draft-js-plugins/buttons"
 
 
 type Props = {
@@ -98,7 +108,23 @@ export const TextArea = ({registerField, registerOptions, toolbarOptions, contro
 			rules={registerOptions}
 			render={({field: {value, onChange}}) => (
 				<div className = "__editor-block">
-					<Toolbar/>
+					<Toolbar>
+					{
+						(externalProps) => (
+							<>
+								<BoldButton {...externalProps} />
+				                <ItalicButton {...externalProps} />
+				                <UnderlineButton {...externalProps} />
+				                <CodeButton {...externalProps} />
+				                <Separator/>
+				                <UnorderedListButton {...externalProps} />
+				                <OrderedListButton {...externalProps} />
+				                <BlockquoteButton {...externalProps} />
+				                <CodeBlockButton {...externalProps} />		
+							</>
+						)
+					}	
+					</Toolbar>
 					<Editor 
 						editorState={value} 
 						onChange={onChange}

--- a/client/src/components/page-elements/TextAreaDisplay.tsx
+++ b/client/src/components/page-elements/TextAreaDisplay.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import "../../styles/textarea.css"
 
 type Props = {
 	rawHTMLString: string	

--- a/client/src/components/page-elements/TextAreaDisplay.tsx
+++ b/client/src/components/page-elements/TextAreaDisplay.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+type Props = {
+	rawHTMLString: string	
+}
+
+/* Display the converted content from Draft.js, ignoring normalized styles */
+export const TextAreaDisplay = ({rawHTMLString}: Props) => {
+	return (
+		<div className = "__editor-block" dangerouslySetInnerHTML={{ __html: rawHTMLString }}></div>
+	)
+}
+

--- a/client/src/styles/common.css
+++ b/client/src/styles/common.css
@@ -212,10 +212,10 @@ ul {
 	padding: 0;
 }
 
-a {
+/*a {
 	text-decoration: none;	
 	color: black;
-}
+}*/
 
 /* :read-only { cursor: default } */
 /*:disabled {

--- a/client/src/styles/common.css
+++ b/client/src/styles/common.css
@@ -212,10 +212,10 @@ ul {
 	padding: 0;
 }
 
-/*a {
+a {
 	text-decoration: none;	
 	color: black;
-}*/
+}
 
 /* :read-only { cursor: default } */
 /*:disabled {

--- a/client/src/styles/edit-ticket-form.css
+++ b/client/src/styles/edit-ticket-form.css
@@ -9,7 +9,7 @@
 	}
 }
 
-.textarea-ignore-global {
+.--ignore-global {
 	ul { 
 	    list-style-type: disc; 
 	    list-style-position: inside; 

--- a/client/src/styles/edit-ticket-form.css
+++ b/client/src/styles/edit-ticket-form.css
@@ -9,35 +9,3 @@
 	}
 }
 
-.--ignore-global {
-	ul { 
-	    list-style-type: disc; 
-	    list-style-position: inside; 
-	}
-	ol { 
-	   list-style-type: decimal; 
-	   list-style-position: inside; 
-	}
-	ul ul, ol ul { 
-	   list-style-type: circle; 
-	   list-style-position: inside; 
-	   margin-left: 15px; 
-	}
-	ol ol, ul ol { 
-	   list-style-type: lower-latin; 
-	   list-style-position: inside; 
-	   margin-left: 15px; 
-	}
-	a {
-		text-decoration: underline;
-		color: blue;
-	}
-	code {
-		font-family: monospace; 
-		font-size: 14px; 
-		overflow-wrap: break-word; 
-		background: rgb(241, 241, 241); 
-		border-radius: 3px; 
-		padding: 1px 3px;
-	}
-}

--- a/client/src/styles/modal.css
+++ b/client/src/styles/modal.css
@@ -25,7 +25,6 @@
 }
 
 .modal {
-	position: relative;
 	max-height:calc(100vh - 125px);
 	overflow: auto
 }

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -14,11 +14,15 @@
     @apply tw-mb-2;
 }
 
-.__editor-block {
+.__editor {
     /* make sure the SVG for plugins are baseline */
     svg {
         @apply tw-align-baseline tw-inline
     }
+}
+
+.__editor-block {
+
     /* remove normalized styling for the following entities */
     blockquote {
         display: block;
@@ -58,5 +62,6 @@
         border-radius: 3px; 
         padding: 1px 3px;
     }
-
 }
+
+

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -1,24 +1,62 @@
 .DraftEditor-root {
-    /* Apply Tailwind classes or extend styles */
     @apply tw-text-gray-800 tw-leading-relaxed;
 }
 
 .public-DraftEditor-content {
-    /* Style the editor content */
     @apply tw-min-h-64 tw-px-4 tw-py-2 tw-text-base tw-bg-white tw-border tw-border-gray-300 tw-rounded-md focus:tw-outline-none;
 }
 
 .public-DraftEditorPlaceholder-root {
-    /* Style the placeholder text */
     @apply tw-text-gray-400 tw-italic;
 }
 
 .public-DraftStyleDefault-block {
-    /* Style individual blocks */
     @apply tw-mb-2;
 }
 
-/* make sure the SVG for plugins are baseline */
 .__editor-block {
-    @apply tw-align-baseline tw-inline
+    /* make sure the SVG for plugins are baseline */
+    svg {
+        @apply tw-align-baseline tw-inline
+    }
+    /* remove normalized styling for the following entities */
+    blockquote {
+        display: block;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 40px;
+        margin-inline-end: 40px;
+        unicode-bidi: isolate;
+    }
+    ul { 
+        list-style-type: disc; 
+        list-style-position: inside; 
+    }
+    ol { 
+       list-style-type: decimal; 
+       list-style-position: inside; 
+    }
+    ul ul, ol ul { 
+       list-style-type: circle; 
+       list-style-position: inside; 
+       margin-left: 15px; 
+    }
+    ol ol, ul ol { 
+       list-style-type: lower-latin; 
+       list-style-position: inside; 
+       margin-left: 15px; 
+    }
+    a {
+        text-decoration: underline;
+        color: blue;
+    }
+    code {
+        font-family: monospace; 
+        font-size: 14px; 
+        overflow-wrap: break-word; 
+        background: rgb(241, 241, 241); 
+        border-radius: 3px; 
+        padding: 1px 3px;
+    }
+
 }

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -1,0 +1,24 @@
+.DraftEditor-root {
+    /* Apply Tailwind classes or extend styles */
+    @apply tw-text-gray-800 tw-leading-relaxed;
+}
+
+.public-DraftEditor-content {
+    /* Style the editor content */
+    @apply tw-min-h-64 tw-px-4 tw-py-2 tw-text-base tw-bg-white tw-border tw-border-gray-300 tw-rounded-md focus:tw-outline-none;
+}
+
+.public-DraftEditorPlaceholder-root {
+    /* Style the placeholder text */
+    @apply tw-text-gray-400 tw-italic;
+}
+
+.public-DraftStyleDefault-block {
+    /* Style individual blocks */
+    @apply tw-mb-2;
+}
+
+/* make sure the SVG for plugins are baseline */
+.__editor-block {
+    @apply tw-align-baseline tw-inline
+}


### PR DESCRIPTION
- The reasoning for the switch was because of react wysiwyg's lack of support for dynamic lists for mentions and lack of customization.
- Notes on getting this to work:
- make sure that the individual plugin CSS files are imported, otherwise there isn't any styling.
- The anchor tags were not being added when using the `link` and `linkify` plugins. Had to change the way I was pulling down `EditorState` changes into the text area by manually tracking a new `EditorState` instance within each text area, and then pulling the changes down.
- TODO: would be to just store a JSON string as the form value, so I don't need to store the `EditorState` there. And then just convert the JSON string to content when creating the new EditorState instance. 
- This works, but it could cause efficiency issues down the road since the editor needs to re-render each time a change is made to it. Look into `useMemo` on the toolbars to save some re-renders.