### PR TITLE
Migration from Draft JS Plugins to Quill

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3062,6 +3062,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
       "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg=="
     },
+    "@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "requires": {
+        "parchment": "^1.1.2"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -4383,6 +4391,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "clsx": {
       "version": "2.1.0",
@@ -6064,10 +6077,20 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -9703,6 +9726,11 @@
         }
       }
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10748,6 +10776,64 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        }
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -11006,6 +11092,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "requires": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      }
     },
     "react-redux": {
       "version": "8.1.3",

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-draft-wysiwyg": "^1.15.0",
     "react-hook-form": "^7.51.1",
     "react-icons": "^5.0.1",
+    "react-quill": "^2.0.0",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",

--- a/client/src/components/AddTicketForm.tsx
+++ b/client/src/components/AddTicketForm.tsx
@@ -23,7 +23,7 @@ import { IconContext } from "react-icons"
 import { LoadingButton } from "./page-elements/LoadingButton"
 import { AsyncSelect } from "./AsyncSelect"
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
-import { Editor } from "react-draft-wysiwyg"
+import { SimpleEditor } from "./page-elements/SimpleEditor"
 import { 
 	TextArea,
 	textAreaValidation, 
@@ -35,7 +35,7 @@ import {
 export type FormValues = {
 	id?: number
 	name: string
-	description: EditorState
+	description: string 
 	priorityId: number
 	statusId: number
 	ticketTypeId: number
@@ -65,7 +65,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 	const defaultForm: FormValues = {
 		id: undefined,
 		name: "",
-		description: EditorState.createEmpty(),
+		description: "",
 		priorityId: 0,
 		statusId: 0,
 		ticketTypeId: 0,
@@ -83,7 +83,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 
 	const registerOptions = {
 	    name: { required: "Name is required" },
-		description: textAreaValidation("Description"),
+		description: { required: "Description is required"},
 	    priorityId: { required: "Priority is required"},
 	    statusId: { required: "Status is required"},
 	    ticketTypeId: { required: "Ticket Type is required"},
@@ -95,7 +95,6 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 		if (ticket){
 			reset({
 				...ticket, 
-				description: convertJSONToEditorState(ticket.description),
 				id: undefined,
 				userId: 0
 			})
@@ -109,7 +108,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
     	try {
 	    	const data = await addTicket({
 	    		...values, 
-	    		description: convertEditorStateToJSON(values.description)
+	    		description: values.description
 	    	}).unwrap()
 	    	if (boardId){
 		    	await addBoardTickets({boardId: boardId, ticketIds: [data.id]}).unwrap()
@@ -162,7 +161,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 						</div>
 						<div>
 							<label className = "label" htmlFor = "ticket-description">Description</label>
-							<TextArea
+							<SimpleEditor
 								registerField={"description"}
 								registerOptions={registerOptions.description}
 							/>

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import { PaginationRow } from "./page-elements/PaginationRow"
 import { TicketRow } from "./TicketRow" 
 import { TICKETS } from "../helpers/routes"
 import { Banner } from "./page-elements/Banner"
+import { SimpleEditor } from "./page-elements/SimpleEditor"
 
 export const Dashboard = () => {
 	const dispatch = useAppDispatch()

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -100,7 +100,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	const defaultForm: FormValues = {
 		id: 0,
 		name: "",
-		description: EditorState.createEmpty(),
+		description: "",
 		priorityId: 0,
 		statusId: 0,
 		ticketTypeId: 0,
@@ -113,7 +113,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	const { register , control, handleSubmit, reset, resetField, setValue, watch, formState: {errors} } = methods
 	const registerOptions = {
 	    name: { required: "Name is required" },
-    	description: textAreaValidation("Description"),
+    	description: { required: "Description is required"},
 	    priorityId: { required: "Priority is required"},
 	    statusId: { required: "Status is required"},
 	    ticketTypeId: { required: "Ticket Type is required"},
@@ -159,8 +159,6 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 		if (currentTicketId){
 			reset({
 				...ticket, 
-				// convert description from JSON representation of content state to editor state
-				description: convertJSONToEditorState(ticket.description),
 				userId: ticketAssignees?.length ? ticketAssignees[0].id : 0
 			} ?? defaultForm
 			)
@@ -182,7 +180,6 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
     		if (values.id != null){
     			await updateTicket({
     				...values, 
-    				description: convertEditorStateToJSON(values.description),
     				id: values.id
     			}).unwrap()
     			// update ticket assignees
@@ -331,7 +328,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									{
 										!editFieldVisibility.description ? (
 											<div onClick = {(e) => toggleFieldVisibility("description", true)} className = "hover:tw-opacity-60 tw-cursor-pointer">
-												<TextAreaDisplay rawHTMLString={convertEditorStateToHTML(watch("description"))}/>
+												<TextAreaDisplay rawHTMLString={watch("description")}/>
 											</div>
 										) : (
 											<div className = "tw-flex tw-flex-col tw-gap-y-2">
@@ -346,11 +343,6 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 													registerField = {"description"} 
 													registerOptions = {registerOptions.description} 
 													type = "textarea" 
-													customReset={() => {
-														if (ticket){
-															setValue("description", convertJSONToEditorState(ticket.description))
-														}
-													}}
 													onCancel={() => toggleFieldVisibility("description", false)}/>
 										        {errors?.description && <small className = "--text-alert">{errors.description.message}</small>}
 											</div>

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import { Controller, useForm, FormProvider, useFormContext } from "react-hook-form"
 import { TextArea } from "./page-elements/TextArea"
 import { LoadingButton } from "./page-elements/LoadingButton"
+import { SimpleEditor } from "./page-elements/SimpleEditor"
 
 type Props = {
 	type: string
@@ -44,7 +45,7 @@ export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customRe
 		case "textarea":
 			element = (
 				<FormProvider {...methods}>
-					<TextArea
+					<SimpleEditor
 						registerField={registerField}
 						registerOptions={registerOptions}
 					/>

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customReset, registerField, registerOptions}: Props) => {
 	const methods = useFormContext()
-	const { control, handleSubmit, register, resetField, setValue } = methods
+	const { control, handleSubmit, register, resetField, getValues, setValue } = methods
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
 		if (e.key === "Escape"){
@@ -75,7 +75,7 @@ export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customRe
 				}}></LoadingButton>
 				<button type = "button" onClick={(e) => {
 					e.preventDefault()
-					customReset ? customReset() : resetField(registerField)
+					customReset ? customReset() : resetField(getValues(registerField))
 					onCancel()
 				}
 				} className = "button --secondary">Cancel</button>

--- a/client/src/components/TicketCommentForm.tsx
+++ b/client/src/components/TicketCommentForm.tsx
@@ -28,12 +28,13 @@ import {
 } from "./page-elements/TextArea"
 import { Avatar } from "./page-elements/Avatar"
 import { TextAreaDisplay } from "./page-elements/TextAreaDisplay"
+import { SimpleEditor } from "./page-elements/SimpleEditor"
 
 type CommentFormValues = {
 	id: number
 	ticketId: number,
 	userId: number,
-	comment: EditorState 
+	comment: string
 }
 
 type CommentFieldProps = {
@@ -49,7 +50,7 @@ export const CommentField = ({isLoading, registerOptions, onSubmit, onCancel}: C
 	return (
 		<form className = "tw-flex tw-flex-col tw-gap-y-2 tw-w-full">
 			<FormProvider {...methods}>
-				<TextArea
+				<SimpleEditor
 					registerField={"comment"}
 					registerOptions={registerOptions}
 				/>
@@ -85,7 +86,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 		id: 0,
 		ticketId: 0,
 		userId: 0,
-		comment: EditorState.createEmpty()
+		comment: "",
 	}
 	const [preloadedValues, setPreloadedValues] = useState<CommentFormValues>(defaultForm)
 	const methods = useForm<CommentFormValues>({
@@ -93,7 +94,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 	})
 	const { register , handleSubmit, reset, setValue, watch, formState: {errors} } = methods
 	const registerOptions = {
-	    comment: textAreaValidation("Comment"),
+	    comment: {required: "Comment is required"},
     }
 	/* 
 	Because only one comment can exist on the form at once, the 
@@ -118,7 +119,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 				{
 					ticketId: currentTicketId,
 					comment: {
-						comment: convertEditorStateToJSON(values.comment),
+						comment: values.comment,
 						ticketId: currentTicketId,
 						userId: userProfile.id
 					}
@@ -130,7 +131,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 					ticketId: values.ticketId,
 					comment: {
 						...values,
-						comment: convertEditorStateToJSON(values.comment)
+						comment: values.comment
 					} 
 				}
 				).unwrap()
@@ -247,7 +248,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 										/>
 									</FormProvider>
 								) : (
-									<TextAreaDisplay rawHTMLString={convertEditorStateToHTML(convertJSONToEditorState(comment.comment))}/>
+									<TextAreaDisplay rawHTMLString={comment.comment}/>
 								)}
 								{comment.userId === userProfile?.id && !showAddCommentForm && !showEditCommentId ? (
 									<div className = "tw-flex tw-flex-row tw-gap-x-2">
@@ -256,7 +257,7 @@ export const TicketCommentForm = ({currentTicketId, ticketComments}: TicketComme
 												id: comment.id,
 												ticketId: comment.ticketId,
 												userId: comment.userId,
-												comment: convertJSONToEditorState(comment.comment)
+												comment: comment.comment,
 											})
 											setShowAddCommentField(false)
 											setShowEditCommentId(comment.id)

--- a/client/src/components/page-elements/SimpleEditor.tsx
+++ b/client/src/components/page-elements/SimpleEditor.tsx
@@ -1,0 +1,31 @@
+import React, {useEffect, useState} from "react"
+import { Controller, FormProvider, useFormContext } from "react-hook-form"
+import ReactQuill from "react-quill"
+import "react-quill/dist/quill.snow.css"
+
+type Props = {
+	registerField: string
+	registerOptions?: Record<string, any> 
+}
+
+
+export const SimpleEditor = ({registerField, registerOptions}: Props) => {
+	const { control, handleSubmit, register, resetField, getValues, setValue } = useFormContext()
+	return (
+		<Controller
+			name={registerField}
+			rules={registerOptions}
+			control={control}
+			render={({field}) => (
+				<ReactQuill 
+					theme = "snow" 
+					value={field.value} 
+					onChange={(text) => {
+						field.onChange(text)
+					}}
+				/>
+			)}
+		/>
+	)
+}
+

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -35,10 +35,12 @@
     ul { 
         list-style-type: disc; 
         list-style-position: inside; 
+        margin-left: 15px; 
     }
     ol { 
        list-style-type: decimal; 
        list-style-position: inside; 
+       margin-left: 15px; 
     }
     ul ul, ol ul { 
        list-style-type: circle; 


### PR DESCRIPTION
* The complexity of Draft JS and Draft JS Plugins proved to be too much as the purpose of the editor for Kanban was to provide basic functionalities without the need for something too complex. 
* Quill is able to provide those functionalities out of the box without any need for customization or hacking around. 