### PR TITLE
Quill Migration Continued

### DIFF
--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -282,6 +282,11 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									<>
 										<InlineEdit 
 											isLoading={isUpdateTicketLoading}
+											customReset={() => {
+												if (ticket?.name){
+													setValue("name", ticket.name)
+												}
+											}}
 											onSubmit = {async () => {
 											await handleSubmit(onSubmit)()
 											if (!errors?.name){
@@ -333,6 +338,11 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 										) : (
 											<div className = "tw-flex tw-flex-col tw-gap-y-2">
 												<InlineEdit 
+													customReset={() => {
+														if (ticket?.description){
+															setValue("description", ticket.description)
+														}
+													}}
 													isLoading={isUpdateTicketLoading}
 													onSubmit={async () => {
 														await handleSubmit(onSubmit)()

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -75,7 +75,7 @@ export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customRe
 				}}></LoadingButton>
 				<button type = "button" onClick={(e) => {
 					e.preventDefault()
-					customReset ? customReset() : resetField(getValues(registerField))
+					customReset ? customReset() : resetField(registerField)
 					onCancel()
 				}
 				} className = "button --secondary">Cancel</button>

--- a/client/src/components/page-elements/SimpleEditor.tsx
+++ b/client/src/components/page-elements/SimpleEditor.tsx
@@ -3,6 +3,7 @@ import { Controller, FormProvider, useFormContext } from "react-hook-form"
 import ReactQuill from "react-quill"
 import "react-quill/dist/quill.snow.css"
 
+
 type Props = {
 	registerField: string
 	registerOptions?: Record<string, any> 
@@ -11,21 +12,43 @@ type Props = {
 
 export const SimpleEditor = ({registerField, registerOptions}: Props) => {
 	const { control, handleSubmit, register, resetField, getValues, setValue } = useFormContext()
+	const modules = {
+		toolbar: [
+			[{ header: [1, 2, 3, false] }],
+			[{ 'color': [] }],
+			[{ 'font': [] }],
+			[{ 'align': [] }],
+			["bold", "italic", "underline", "strike", "blockquote"],
+			[
+				{ list: "ordered" },
+				{ list: "bullet" },
+				{ indent: "-1" },
+				{ indent: "+1" }
+			],
+			["link", "code-block"],
+			["clean"],
+		]
+	}
 	return (
-		<Controller
-			name={registerField}
-			rules={registerOptions}
-			control={control}
-			render={({field}) => (
-				<ReactQuill 
-					theme = "snow" 
-					value={field.value} 
-					onChange={(text) => {
-						field.onChange(text)
-					}}
-				/>
-			)}
-		/>
+		<div id="quillContainer">
+			<Controller
+				name={registerField}
+				rules={registerOptions}
+				control={control}
+				render={({field}) => (
+					<ReactQuill 
+						modules={modules}
+						/* prevent quill popups from going out of bounds*/
+						bounds={'#quillContainer'}
+						theme = "snow" 
+						value={field.value} 
+						onChange={(text) => {
+							field.onChange(text)
+						}}
+					/>
+				)}
+			/>
+		</div>
 	)
 }
 

--- a/client/src/components/page-elements/TextAreaDisplay.tsx
+++ b/client/src/components/page-elements/TextAreaDisplay.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import "../../styles/textarea.css"
+import "react-quill/dist/quill.snow.css"
 
 type Props = {
 	rawHTMLString: string	
@@ -8,7 +9,7 @@ type Props = {
 /* Display the converted content from Draft.js, ignoring normalized styles */
 export const TextAreaDisplay = ({rawHTMLString}: Props) => {
 	return (
-		<div className = "__editor-block" dangerouslySetInnerHTML={{ __html: rawHTMLString }}></div>
+		<div className = "ql-editor" dangerouslySetInnerHTML={{ __html: rawHTMLString }}></div>
 	)
 }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -7,18 +7,17 @@ import { Provider } from "react-redux"
 import { store } from "./store"
 import { render } from "react-dom"; 
 
-// const root = ReactDOM.createRoot(
-//   document.getElementById('root') as HTMLElement
-// );
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
 
 // the change to render is necessary for the React WYSIWYG toolbar dropdowns to work
-render(
+root.render(
   <React.StrictMode>
     <Provider store={store}>
    			<App/>
     </Provider>
   </React.StrictMode>,
-  document.getElementById("root")
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -1,3 +1,26 @@
+.DraftEditor-root {
+    @apply tw-text-gray-800 tw-leading-relaxed;
+}
+
+.public-DraftEditor-content {
+    @apply tw-min-h-64 tw-px-4 tw-py-2 tw-text-base tw-bg-white tw-border tw-border-gray-300 tw-rounded-md focus:tw-outline-none;
+}
+
+.public-DraftEditorPlaceholder-root {
+    @apply tw-text-gray-400 tw-italic;
+}
+
+.public-DraftStyleDefault-block {
+    @apply tw-mb-2;
+}
+
+.__editor {
+    /* make sure the SVG for plugins are baseline */
+    svg {
+        @apply tw-align-baseline tw-inline
+    }
+}
+
 .__editor-block {
 
     /* remove normalized styling for the following entities */

--- a/client/src/styles/textarea.css
+++ b/client/src/styles/textarea.css
@@ -1,26 +1,3 @@
-.DraftEditor-root {
-    @apply tw-text-gray-800 tw-leading-relaxed;
-}
-
-.public-DraftEditor-content {
-    @apply tw-min-h-64 tw-px-4 tw-py-2 tw-text-base tw-bg-white tw-border tw-border-gray-300 tw-rounded-md focus:tw-outline-none;
-}
-
-.public-DraftEditorPlaceholder-root {
-    @apply tw-text-gray-400 tw-italic;
-}
-
-.public-DraftStyleDefault-block {
-    @apply tw-mb-2;
-}
-
-.__editor {
-    /* make sure the SVG for plugins are baseline */
-    svg {
-        @apply tw-align-baseline tw-inline
-    }
-}
-
 .__editor-block {
 
     /* remove normalized styling for the following entities */


### PR DESCRIPTION
* Added more buttons to the text editor such as font styling, code blocks, etc
* Also re-fixed the issue with the cancel button on the inline edits not resetting to the proper state. It should just set based on the last inserted value on the ticket.

https://github.com/user-attachments/assets/0335288c-1e51-4ea3-ab05-fa27a3bfe308

