### PR TITLE
POC for Mentions using `react-quill` and `quill-mentions`

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10834,6 +10834,14 @@
         }
       }
     },
+    "quill-mention": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/quill-mention/-/quill-mention-4.1.0.tgz",
+      "integrity": "sha512-dT8HLYeuGU8yjjUr5SgdOusFSqQ7FQt/DWefz4V/L2omJsZ9CVYWepg3GyqV/evNDV7LQtfM7cadxtYD2bi2ew==",
+      "requires": {
+        "quill": "^1.3.7"
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "draft-js": "^0.11.7",
     "draft-js-export-html": "^1.4.1",
     "jest": "^27.5.1",
+    "quill-mention": "^4.1.0",
     "react": "^18.2.0",
     "react-datetime-picker": "^5.5.2",
     "react-dom": "^18.2.0",

--- a/client/src/components/AddTicketForm.tsx
+++ b/client/src/components/AddTicketForm.tsx
@@ -164,6 +164,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 							<SimpleEditor
 								registerField={"description"}
 								registerOptions={registerOptions.description}
+								mentionsEnabled={true}
 							/>
 					        {errors?.description && <small className = "--text-alert">{errors.description.message}</small>}
 					    </div>

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -71,8 +71,8 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	const [ linkedTicketPage, setLinkedTicketPage ] = useState(1)
 	const [ commentPage, setCommentPage ] = useState(1)
 	const { data: reporter, isLoading: isUserLoading } = useGetUserQuery(ticket?.userId ?? skipToken)
-	const { data: ticketAssignees, isLoading: isTicketAssigneesLoading } = useGetTicketAssigneesQuery(currentTicketId ? {ticketId: currentTicketId, params: {isWatcher: false}} : skipToken)
-	const { data: ticketWatchers, isLoading: isTicketWatchersLoading } = useGetTicketAssigneesQuery(currentTicketId ? {ticketId: currentTicketId, params: {isWatcher: true}} : skipToken)
+	const { data: ticketAssignees, isLoading: isTicketAssigneesLoading } = useGetTicketAssigneesQuery(currentTicketId ? {ticketId: currentTicketId, params: {isWatcher: false, isMention: false}} : skipToken)
+	const { data: ticketWatchers, isLoading: isTicketWatchersLoading } = useGetTicketAssigneesQuery(currentTicketId ? {ticketId: currentTicketId, params: {isWatcher: true, isMention: false}} : skipToken)
 	const { data: ticketComments, isLoading: isTicketCommentsLoading } = useGetTicketCommentsQuery(currentTicketId ? {ticketId: currentTicketId, params: {page: commentPage}} : skipToken)
 	const { data: ticketRelationships, isLoading: isTicketRelationshipsLoading } = useGetTicketRelationshipsQuery(currentTicketId ? 
 		{ticketId: currentTicketId, params: {page: linkedTicketPage, isEpic: false}} : skipToken

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -282,6 +282,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									<>
 										<InlineEdit 
 											isLoading={isUpdateTicketLoading}
+											mentionsEnabled={false}
 											customReset={() => {
 												if (ticket?.name){
 													setValue("name", ticket.name)
@@ -338,6 +339,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 										) : (
 											<div className = "tw-flex tw-flex-col tw-gap-y-2">
 												<InlineEdit 
+													mentionsEnabled={true}
 													customReset={() => {
 														if (ticket?.description){
 															setValue("description", ticket.description)

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -17,7 +17,7 @@ import { useGetUserQuery } from "../services/private/userProfile"
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { InlineEdit } from "./InlineEdit" 
 import { Controller, useForm, FormProvider } from "react-hook-form"
-import { OptionType, Ticket, TicketType, Priority, Status, UserProfile } from "../types/common"
+import { OptionType, Mention, Ticket, TicketType, Priority, Status, UserProfile } from "../types/common"
 import { FormValues } from "./AddTicketForm" 
 import { addToast } from "../slices/toastSlice" 
 import { v4 as uuidv4 } from "uuid"
@@ -47,6 +47,7 @@ import {
 } from "./page-elements/TextArea"
 import { TextAreaDisplay } from "./page-elements/TextAreaDisplay"
 import { Avatar } from "./page-elements/Avatar"
+import { useAddNotificationMutation, useBulkCreateNotificationsMutation } from "../services/private/notification"
 
 type EditFieldVisibility = {
 	[key: string]: boolean
@@ -66,6 +67,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	const { userProfile } = useAppSelector((state) => state.userProfile)
 	const { userRoles } = useAppSelector((state) => state.userRole) 
 	const { priorities } = useAppSelector((state) => state.priority) 
+	const { notificationTypes } = useAppSelector((state) => state.notificationType) 
 	const { ticketTypes } = useAppSelector((state) => state.ticketType) 
 	const [ epicTicketPage, setEpicTicketPage ] = useState(1)
 	const [ linkedTicketPage, setLinkedTicketPage ] = useState(1)
@@ -82,11 +84,14 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 	)
 	const [ updateTicket, {isLoading: isUpdateTicketLoading, error: isUpdateTicketError} ] = useUpdateTicketMutation() 
 	const [ bulkEditTicketAssignees ] = useBulkEditTicketAssigneesMutation()
+	const [ addNotification, {isLoading: isAddNotificationLoading}] = useAddNotificationMutation()
+	const [ bulkCreateNotifications, {isLoading: isBulkCreateNotificationLoading}] = useBulkCreateNotificationsMutation()
 	const {
 		showModal
 	} = useAppSelector((state) => state.modal)
 	const isCompletedStatusIds = statuses.filter((status) => status.isCompleted).map((status) => status.id)
 	const createdAt = ticket?.createdAt ? new Date(ticket?.createdAt).toLocaleDateString() : ""
+	const mentionNotificationType = notificationTypes?.find((notif) => notif.name === "Mention")
 
 	const [editFieldVisibility, setEditFieldVisibility] = useState<EditFieldVisibility>({
 		"name": false,
@@ -178,10 +183,22 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
     	try {
     		// update existing ticket
     		if (values.id != null){
-    			await updateTicket({
+    			const { mentions } = await updateTicket({
     				...values, 
     				id: values.id
     			}).unwrap()
+    			if (mentionNotificationType && userProfile && mentions.length){
+	    			const notifications = mentions.map((mention: Mention) => {
+	    				return {
+							recipientId: mention.userId,
+							senderId: userProfile.id,
+							ticketId: mention.ticketId,
+							objectLink: `${TICKETS}/${mention.ticketId}`,
+							notificationTypeId: mentionNotificationType.id,
+						}
+	    			})
+					await bulkCreateNotifications(notifications).unwrap()
+    			}
     			// update ticket assignees
     			// TODO: need to update this line to include all userIds if allowing multiple 
     			// assignees per ticket

--- a/client/src/components/InlineEdit.tsx
+++ b/client/src/components/InlineEdit.tsx
@@ -13,9 +13,21 @@ type Props = {
 	registerField: string
 	registerOptions: Record<string, any>
 	isLoading?: boolean
+	mentionsEnabled?: boolean
 }
 
-export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customReset, registerField, registerOptions}: Props) => {
+export const InlineEdit = (
+	{
+		isLoading, 
+		type, 
+		value, 
+		onSubmit, 
+		onCancel, 
+		customReset, 
+		registerField, 
+		registerOptions, 
+		mentionsEnabled
+	}: Props) => {
 	const methods = useFormContext()
 	const { control, handleSubmit, register, resetField, getValues, setValue } = methods
 
@@ -48,6 +60,7 @@ export const InlineEdit = ({isLoading, type, value, onSubmit, onCancel, customRe
 					<SimpleEditor
 						registerField={registerField}
 						registerOptions={registerOptions}
+						mentionsEnabled={mentionsEnabled}
 					/>
 				</FormProvider>
 			)

--- a/client/src/components/TicketCommentForm.tsx
+++ b/client/src/components/TicketCommentForm.tsx
@@ -53,6 +53,7 @@ export const CommentField = ({isLoading, registerOptions, onSubmit, onCancel}: C
 				<SimpleEditor
 					registerField={"comment"}
 					registerOptions={registerOptions}
+					mentionsEnabled={true}
 				/>
 			</FormProvider>
 	        {errors?.comment && <small className = "--text-alert">{errors.comment.message}</small>}

--- a/client/src/components/page-elements/SimpleEditor.tsx
+++ b/client/src/components/page-elements/SimpleEditor.tsx
@@ -1,18 +1,41 @@
-import React, {useEffect, useState} from "react"
+import React, {useEffect, useState, useCallback} from "react"
 import { Controller, FormProvider, useFormContext } from "react-hook-form"
-import ReactQuill from "react-quill"
+import ReactQuill, {Quill} from "react-quill"
+import "quill-mention";
 import "react-quill/dist/quill.snow.css"
-
 
 type Props = {
 	registerField: string
 	registerOptions?: Record<string, any> 
 }
 
-
 export const SimpleEditor = ({registerField, registerOptions}: Props) => {
 	const { control, handleSubmit, register, resetField, getValues, setValue } = useFormContext()
 	const modules = {
+		mention: {
+			allowedChars: /^[A-Za-z\sÅÄÖåäö]*$/, 
+			mentionDenotationChars: ["@"],
+			source: useCallback((searchTerm: string, renderList: Function, mentionChar: string) => {
+				const atValues = [
+					{ id: 1, value: "Fredrik Sundqvist" },
+					{ id: 2, value: "Patrik Sjölin" },
+					{ id: 3, value: "Ludwig Beethoven" },
+				]
+				if (searchTerm.length === 0){
+					renderList(atValues, searchTerm)
+				}
+				else {
+					const matches = []
+					for (let i = 0; i < atValues.length; ++i){
+						// const matched = atValues[i].value.toLowerCase().indexOf(searchTerm.toLowerCase())
+						if (~atValues[i].value.toLowerCase().indexOf(searchTerm.toLowerCase())){
+							matches.push(atValues[i])
+						}
+					}
+					renderList(matches, searchTerm)
+				}
+			}, [])
+		},
 		toolbar: [
 			[{ header: [1, 2, 3, false] }],
 			[{ 'color': [] }],

--- a/client/src/components/page-elements/SimpleEditor.tsx
+++ b/client/src/components/page-elements/SimpleEditor.tsx
@@ -3,39 +3,43 @@ import { Controller, FormProvider, useFormContext } from "react-hook-form"
 import ReactQuill, {Quill} from "react-quill"
 import "quill-mention";
 import "react-quill/dist/quill.snow.css"
+import "quill-mention/dist/quill.mention.css"
+import { useLazyGenericFetchQuery } from "../../services/private/generic"
+import { USER_PROFILE_URL } from "../../helpers/urls"
 
 type Props = {
 	registerField: string
 	registerOptions?: Record<string, any> 
+	mentionsEnabled?: boolean
+	mentionsUrl?: string
+	mentionsUrlParams?: Record<string, any>
 }
 
-export const SimpleEditor = ({registerField, registerOptions}: Props) => {
+export const SimpleEditor = ({registerField, registerOptions, mentionsEnabled, mentionsUrl, mentionsUrlParams}: Props) => {
 	const { control, handleSubmit, register, resetField, getValues, setValue } = useFormContext()
+	const [ genericFetch ] = useLazyGenericFetchQuery()
+	const source = useCallback(async (searchTerm: string, renderList: Function, _: string) => {
+		/* TODO: figure how to integrate react select with this component (if possible with this library),
+			or alternatively figure out how to enable scrolling with pagination, with loading indicators.
+		*/
+		const {data, pagination} = await genericFetch({
+			endpoint: mentionsUrl ?? USER_PROFILE_URL,
+			urlParams: 
+			mentionsUrlParams ? {...mentionsUrlParams, isMentions: true, query: searchTerm ?? ""} : {
+				forSelect: true, 
+				filterOnUserRole: true, 
+				query: searchTerm ?? "",
+				isMentions: true,
+			},
+		}).unwrap()
+		renderList(data, searchTerm)
+	}, [])
 	const modules = {
-		mention: {
+		...(mentionsEnabled ? {mention: {
 			allowedChars: /^[A-Za-z\sÅÄÖåäö]*$/, 
 			mentionDenotationChars: ["@"],
-			source: useCallback((searchTerm: string, renderList: Function, mentionChar: string) => {
-				const atValues = [
-					{ id: 1, value: "Fredrik Sundqvist" },
-					{ id: 2, value: "Patrik Sjölin" },
-					{ id: 3, value: "Ludwig Beethoven" },
-				]
-				if (searchTerm.length === 0){
-					renderList(atValues, searchTerm)
-				}
-				else {
-					const matches = []
-					for (let i = 0; i < atValues.length; ++i){
-						// const matched = atValues[i].value.toLowerCase().indexOf(searchTerm.toLowerCase())
-						if (~atValues[i].value.toLowerCase().indexOf(searchTerm.toLowerCase())){
-							matches.push(atValues[i])
-						}
-					}
-					renderList(matches, searchTerm)
-				}
-			}, [])
-		},
+			source: source 
+		}} : {}),
 		toolbar: [
 			[{ header: [1, 2, 3, false] }],
 			[{ 'color': [] }],

--- a/client/src/components/page-elements/TopNav.tsx
+++ b/client/src/components/page-elements/TopNav.tsx
@@ -34,11 +34,15 @@ export const TopNav = () => {
 	const [lastId, setLastId] = useState(0)
 	const [currentNotifications, setCurrentNotifications] = useState<Array<Notification>>([])
 
-	const { data: notifications, isLoading: isGetNotificationsLoading } = useGetNotificationsQuery({}) 
-	const { data: newNotifications, isLoading: isGetNewNotificationsLoading } = usePollNotificationsQuery(lastId !== 0 ? {lastId: lastId} : skipToken, {
-		pollingInterval: 31000,
-		// skipPollingIfUnfocused: true
-	})
+	const { data: notifications, isLoading: isGetNotificationsLoading } = useGetNotificationsQuery({}, {
+		pollingInterval: 30000,
+		skipPollingIfUnfocused: true
+	}) 
+	// TODO: need to figure out why this causes other cache invalidation requests to lag (i.e add/remove ticket watchers)
+	// const { data: newNotifications, isLoading: isGetNewNotificationsLoading } = usePollNotificationsQuery(lastId !== 0 ? {lastId: lastId} : skipToken, {
+	// 	pollingInterval: 31000,
+	// 	// skipPollingIfUnfocused: true
+	// })
 
     const [ updateNotification, { error: updateNotificationError, isLoading: isUpdateNotificationLoading} ] = useUpdateNotificationMutation();
     const [ bulkEditNotifications, { error: bulkEditNotificationsError, isLoading: isBulkEditNotificationsLoading }] = useBulkEditNotificationsMutation()
@@ -55,17 +59,17 @@ export const TopNav = () => {
 		}
 	}, [notifications])
 
-	useEffect(() => {
-		if (newNotifications && newNotifications?.length > 0){
-			const unreadMessages = newNotifications.filter(n => !n.isRead)
-			const newLastUnreadId = Math.max(...unreadMessages.map(n => n.id))
-			if (lastId < newLastUnreadId){
-				setLastId(Math.max(...newNotifications.map(n => n.id)))
-			}
-			setShowIndicator(unreadMessages.length > 0)
-			setCurrentNotifications([...newNotifications, ...currentNotifications])
-		}
-	}, [newNotifications])
+	// useEffect(() => {
+	// 	if (newNotifications && newNotifications?.length > 0){
+	// 		const unreadMessages = newNotifications.filter(n => !n.isRead)
+	// 		const newLastUnreadId = Math.max(...unreadMessages.map(n => n.id))
+	// 		if (lastId < newLastUnreadId){
+	// 			setLastId(Math.max(...newNotifications.map(n => n.id)))
+	// 		}
+	// 		setShowIndicator(unreadMessages.length > 0)
+	// 		setCurrentNotifications([...newNotifications, ...currentNotifications])
+	// 	}
+	// }, [newNotifications])
 
 	useEffect(() => {
 		if (userProfile && Object.keys(userProfile).length){

--- a/client/src/services/private/generic.ts
+++ b/client/src/services/private/generic.ts
@@ -11,7 +11,17 @@ export const genericApi = privateApi.injectEndpoints({
 				method: "GET",	
 				params: urlParams
 			}),
-			transformResponse: (responseData: ListResponse<any>) => {
+			transformResponse: (responseData: ListResponse<any>, meta: unknown, arg: Record<string, any>) => {
+				// for mentions, the list values are different from async select's
+				if (arg.urlParams.isMentions){
+					return {
+						...responseData,
+						data: responseData.data.map((d) => ({
+							id: d.id,
+							value: d.name,
+						}))
+					}
+				}
 				return {
 					...responseData,
 					data: responseData.data.map((d) => ({

--- a/client/src/services/private/notification.ts
+++ b/client/src/services/private/notification.ts
@@ -53,6 +53,22 @@ export const notificationApi = privateApi.injectEndpoints({
 			}),
 			invalidatesTags: ["Notifications"]
 		}),
+		bulkCreateNotifications: builder.mutation<{message: string}, Array<NotificationRequest>>({
+			query: (notifications) => ({
+				url: `${NOTIFICATION_URL}/bulk-create`,
+				method: "POST",
+				body: {
+					notifications: notifications.map(({recipientId, senderId, ticketId, objectLink, notificationTypeId}) => ({
+						recipient_id: recipientId,
+						sender_id: senderId,
+						ticket_id: ticketId,
+						object_link: objectLink,
+						notification_type_id: notificationTypeId,
+					}))
+				} 
+			}),
+			invalidatesTags: ["Notifications"]
+		}),
 		bulkEditNotifications: builder.mutation<{message: string}, {ids: Array<number>, isRead: boolean}>({
 			query: ({ids, isRead}) => ({
 				url: `${NOTIFICATION_URL}/bulk-edit`,
@@ -73,4 +89,5 @@ export const {
 	useAddNotificationMutation,
 	useUpdateNotificationMutation,
 	useBulkEditNotificationsMutation,
+	useBulkCreateNotificationsMutation,
 } = notificationApi

--- a/client/src/services/private/ticket.ts
+++ b/client/src/services/private/ticket.ts
@@ -11,7 +11,7 @@ import {
 	TICKET_RELATIONSHIP_URL,
 } 
 from "../../helpers/urls" 
-import { CustomError, ListResponse, Ticket, TicketComment, TicketRelationship, UserProfile } from "../../types/common" 
+import { CustomError, Mention, ListResponse, Ticket, TicketComment, TicketRelationship, UserProfile } from "../../types/common" 
 import { privateApi } from "../private"
 
 type TicketAssigneeRequest = {
@@ -91,7 +91,7 @@ export const ticketApi = privateApi.injectEndpoints({
 			}),
 			providesTags: ["TicketComments"]
 		}),
-		addTicketComment: builder.mutation<{id: number, message: string}, AddTicketCommentRequest>({
+		addTicketComment: builder.mutation<{id: number, message: string, mentions: Array<Mention>}, AddTicketCommentRequest>({
 			query: ({ticketId, comment}) => ({
 				url: TICKET_COMMENT_URL(ticketId, ""),
 				method: "POST",
@@ -103,7 +103,7 @@ export const ticketApi = privateApi.injectEndpoints({
 			}),
 			invalidatesTags: ["TicketComments"]
 		}),
-		updateTicketComment: builder.mutation<{id: number, message: string}, UpdateTicketCommentRequest>({
+		updateTicketComment: builder.mutation<{id: number, message: string, mentions: Array<Mention>}, UpdateTicketCommentRequest>({
 			query: ({ticketId, comment}) => ({
 				url: TICKET_COMMENT_URL(ticketId, comment.id),
 				method: "PUT",
@@ -164,7 +164,7 @@ export const ticketApi = privateApi.injectEndpoints({
 			}),
 			invalidatesTags: ["TicketAssignees"],
 		}),
-		addTicket: builder.mutation<{id: number, message: string}, Omit<Ticket, "organizationId" | "id" | "createdAt">>({
+		addTicket: builder.mutation<{id: number, message: string, mentions: Array<Mention>}, Omit<Ticket, "organizationId" | "id" | "createdAt">>({
 			query: (ticket) => ({
 				url: `${TICKET_URL}`,
 				method: "POST",
@@ -178,7 +178,7 @@ export const ticketApi = privateApi.injectEndpoints({
 			}),
 			invalidatesTags: ["Tickets"]
 		}),
-		updateTicket: builder.mutation<{message: string}, Omit<Ticket, "organizationId" | "createdAt">>({
+		updateTicket: builder.mutation<{message: string, mentions: Array<Mention>}, Omit<Ticket, "organizationId" | "createdAt">>({
 			query: (ticket) => ({
 				url: `${TICKET_URL}/${ticket.id}`,
 				method: "PUT",

--- a/client/src/types/common.ts
+++ b/client/src/types/common.ts
@@ -157,3 +157,9 @@ export interface Notification {
 	senderId: number
 	createdAt: Date
 }
+
+export interface Mention {
+    userId: number;
+    [key: string]: any;
+}
+

--- a/server/db/migrations/20250111005742_add_mentions_to_tickets.js
+++ b/server/db/migrations/20250111005742_add_mentions_to_tickets.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+	return knex.schema.alterTable("tickets_to_users", function(table){
+		table.boolean("is_mention").defaultTo(false)
+	}) 	
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+	return knex.schema.alterTable("tickets_to_users", function(table){
+		table.dropColumn("is_mention")
+	})  
+};

--- a/server/db/migrations/20250111010532_ticket_comments_to_users.js
+++ b/server/db/migrations/20250111010532_ticket_comments_to_users.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+	return knex.schema.createTable("ticket_comments_to_users", (table) => {
+		table.increments("id").primary()
+		table.integer("ticket_comment_id").unsigned().notNullable()
+		table.integer("user_id").unsigned().notNullable()
+		table.foreign("ticket_comment_id").references("ticket_comments.id").onDelete("cascade")
+		table.foreign("user_id").references("users.id").onDelete("cascade")
+		table.timestamp('created_at').defaultTo(knex.fn.now());	
+ 		table.timestamp('updated_at').defaultTo(knex.raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
+	}) 	
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+	return knex.schema.dropTableIfExists("ticket_comments_to_users") 
+};

--- a/server/db/seeds/notification_types.js
+++ b/server/db/seeds/notification_types.js
@@ -6,8 +6,9 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('notification_types').del()
   await knex('notification_types').insert([
-    {id: 1, name: "Watching Ticket", template: "{{recipient_id} is now watching the ticket: {{ticket_name}}"},
-    {id: 2, name: "Mention", template: "{{sender_id}} has mentioned you here: {{ticket_name}}"},
-    {id: 3, name: "Ticket Update", template: "{{sender_id}} has updated the ticket: {{ticket_name}}"},
+    {id: 1, name: "Watching Ticket", template: "{{{recipient_name}}} is now watching the ticket: {{{ticket_name}}}"},
+    {id: 2, name: "Mention", template: "{{{sender_name}}} has mentioned you here: {{{ticket_name}}}"},
+    {id: 3, name: "Ticket Update", template: "{{{sender_name}}} has updated the ticket: {{{ticket_name}}}"},
+    {id: 4, name: "Ticket Assigned", template: "{{{sender_name}}} has assigned you to the ticket: {{{ticket_name}}}"},
   ]);
 };

--- a/server/helpers/functions.js
+++ b/server/helpers/functions.js
@@ -73,16 +73,16 @@ const mapIdToRowObject = (dbObjArray) => {
 }
 
 /* Parses the notification type template using mustache.js */
-const getNotificationBody = async (notificationType, request) => {
+const getNotificationBody = async (notificationType, obj) => {
 	let fields = {} 
-	const ticket = await db("tickets").where("id", request.body.ticket_id).first()
+	const ticket = await db("tickets").where("id", obj.ticket_id).first()
 	let recipient;
 	let sender
-	if (request.body.recipient_id){
-		recipient = await db("users").where("id", request.body.recipient_id).first()
+	if (obj.recipient_id){
+		recipient = await db("users").where("id", obj.recipient_id).first()
 	}
-	if (request.body.sender_id){
-		sender = await db("users").where("id", request.body.sender_id).first()
+	if (obj.sender_id){
+		sender = await db("users").where("id", obj.sender_id).first()
 	}
 	switch (notificationType.name){
 		case "Watching Ticket":

--- a/server/helpers/functions.js
+++ b/server/helpers/functions.js
@@ -98,7 +98,6 @@ const getNotificationBody = async (notificationType, request) => {
 				fields = {
 					ticket_name: ticket?.name, 	
 					sender_name: `${sender?.first_name} ${sender.last_name}`,
-					recipient_name: `${recipient?.first_name} ${recipient?.last_name}`
 				}
 			}
 			break
@@ -107,7 +106,14 @@ const getNotificationBody = async (notificationType, request) => {
 				fields = {
 					ticket_name: ticket?.name, 	
 					sender_name: `${sender?.first_name} ${sender?.last_name}`,
-					recipient_name: `${recipient?.first_name} ${recipient?.last_name}`
+				}
+			}
+			break
+		case "Ticket Assigned":	
+			if (ticket && sender && recipient){
+				fields = {
+					ticket_name: ticket?.name, 	
+					sender_name: `${sender?.first_name} ${sender?.last_name}`,
 				}
 			}
 			break

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -230,6 +230,11 @@
         }
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -478,6 +483,23 @@
         "vary": "^1"
       }
     },
+    "css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -553,6 +575,39 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
     "dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -580,6 +635,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "es-define-property": {
       "version": "1.0.0",
@@ -1506,6 +1566,15 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "requires": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "nodemailer": {
       "version": "6.9.16",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
@@ -1565,6 +1634,14 @@
         "console-control-strings": "^1.1.0",
         "gauge": "^3.0.0",
         "set-blocking": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
       }
     },
     "object-assign": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "mustache": "^4.2.0",
     "mysql": "^2.18.1",
     "mysql2": "^3.9.2",
+    "node-html-parser": "^7.0.1",
     "nodemailer": "^6.9.16",
     "nodemon": "^3.1.0"
   }

--- a/server/routes/ticket.js
+++ b/server/routes/ticket.js
@@ -22,6 +22,7 @@ const {
 const { handleValidationResult }  = require("../middleware/validationMiddleware")
 const { parseMentions } = require("../helpers/functions")
 const db = require("../db/db")
+const { getNotificationBody } = require("../helpers/functions")
 
 router.get("/", async (req, res, next) => {
 	try {
@@ -176,7 +177,12 @@ router.post("/", validateCreate, handleValidationResult, async (req, res, next) 
 		if (ticketsToUsers.length){
 			await db("tickets_to_users").insert(ticketsToUsers)
 		}
-		res.json({id: id[0], message: "Ticket inserted successfully!"})
+		res.json({id: id[0], mentions: ticketsToUsers.map((obj) => {
+			return {
+				userId: obj.user_id,
+				ticketId: obj.ticket_id,
+			}
+		}), message: "Ticket inserted successfully!"})
 	}	
 	catch (err) {
 		console.error(`Error while creating ticket: ${err.message}`)
@@ -346,7 +352,12 @@ router.post("/:ticketId/comment", validateTicketCommentCreate, handleValidationR
 		if (ticketCommentsToUsers.length){
 			await db("ticket_comments_to_users").insert(ticketCommentsToUsers)
 		}
-		res.json({id: id[0], message: "Comment inserted successfully!"})
+		res.json({id: id[0], mentions: ticketCommentsToUsers.map((obj) => {
+			return {
+				ticketCommentId: obj.ticket_comment_id,
+				userId: obj.user_id,
+			}
+		}), message: "Comment inserted successfully!"})
 	}
 	catch (err){
 		console.log(`Error while creating comment for ticket: ${err.message}`)
@@ -365,7 +376,12 @@ router.put("/:ticketId/comment/:commentId", validateTicketCommentUpdate, handleV
 			await db("ticket_comments_to_users").where("ticket_comment_id", req.params.commentId).del()
 			await db("ticket_comments_to_users").insert(ticketCommentsToUsers)
 		}
-		res.json({message: "Comment updated successfully!"})
+		res.json({mentions: ticketCommentsToUsers.map((obj) => {
+			return {
+				ticketCommentId: obj.ticket_comment_id,
+				userId: obj.user_id,
+			}
+		}), message: "Comment updated successfully!"})
 	}	
 	catch (err) {
 		console.log(`Error while updating comment: ${err.message}`)
@@ -481,7 +497,12 @@ router.put("/:ticketId", validateUpdate, handleValidationResult, async (req, res
 			await db("tickets_to_users").where("ticket_id", req.params.ticketId).where("is_mention", true).del()
 			await db("tickets_to_users").insert(ticketsToUsers)
 		}
-		res.json({message: "Ticket updated successfully!"})
+		res.json({mentions: ticketsToUsers.map((obj) => {
+			return {
+				userId: obj.user_id,
+				ticketId: obj.ticket_id,
+			}
+		}), message: "Ticket updated successfully!"})
 	}	
 	catch (err) {
 		console.error(`Error while updating ticket: ${err.message}`)


### PR DESCRIPTION
* Changed Text Area from `Draft.js` to `react-quill` and utilized `quill-mentions` for the mentions UI on the text area. This ended up being a much simpler change than I thought, as react quill saves its content directly as an HTML string rather than JSON. 
* Used `node-html-parser` library to parse the content in order to retrieve the `user-id` data attributes from the mention html elements on the backend, and create the mentions on the database side.
* When the backend creates the mention, it will determine which mentions are new, and then respond to the frontend with the new mentions. Then, the frontend will take the new mentions and `bulk-create` notifications for the users mentioned.
* Fixed a few bugs that were introduced as a result of differentiating between `is_mention` and `is_watcher ` on the backend for ticket users.
* TODO: as a compromise, I had to change the notifications long poll to a short poll instead. For some reason, the long poll was causing the cache invalidation for certain tags to lag behind. For example, if I re-assigned a user to the ticket or added a new watcher, it would take ~30 seconds to refresh the cache and reflect the changes on the UI. The ~30 second time led me to believe it was due to the long polling. The short polling will likely be fine for now, but in the future, I'd like to change this to use SSE or web sockets.

https://github.com/user-attachments/assets/d0edbaeb-ea0e-4b9f-8c61-2ea166140b1e

