### PR TITLE
remove deleted dependency

### DIFF
--- a/client/src/components/notifications/Filters.tsx
+++ b/client/src/components/notifications/Filters.tsx
@@ -5,8 +5,6 @@ import { NotificationType, UserProfile } from "../../types/common"
 import { LoadingSpinner } from "../LoadingSpinner"
 import { USER_PROFILE_URL } from "../../helpers/urls"
 import { AsyncSelect, LoadOptionsType } from "../../components/AsyncSelect"
-import DatePicker from 'react-date-picker';
-
 
 export const Filters = () => {
 	const { notificationTypes } = useAppSelector((state) => state.notificationType)


### PR DESCRIPTION
* forgot to remove this dependency when removing `react-datepicker`. I'm not sure how this managed to slip through as I didn't notice it throwing an error in development.