### PR TITLE
Add Edit Statuses invalidate board status cache

### DIFF
--- a/client/src/components/primary-modals/OrganizationStatusModal.tsx
+++ b/client/src/components/primary-modals/OrganizationStatusModal.tsx
@@ -117,7 +117,9 @@ export const OrganizationStatusModal = () => {
 				const status = statusData.find((status) => status.id === statusId)
 				// we also need to find the status that currently has the order and swap places
 				const statusToSwap = statusData.find((status) => status.order === newOrder)
-				if (status && statusToSwap){
+				// TODO: there are rare instances where the cache does not update
+				// prevent two statuses from having the same order
+				if (status && statusToSwap && newOrder !== status.order){
 					await updateOrder([{
 						id: status.id,
 						order: newOrder

--- a/client/src/services/private/status.ts
+++ b/client/src/services/private/status.ts
@@ -43,7 +43,7 @@ export const statusApi = privateApi.injectEndpoints({
 					is_active: isActive
 				}
 			}),
-			invalidatesTags: ["Statuses"]
+			invalidatesTags: ["Statuses", "BoardStatuses"]
 		}),
 		updateStatus: builder.mutation<{message: string}, UpdateStatusRequest>({
 			query: ({id, name, order, isActive}) => ({
@@ -53,7 +53,7 @@ export const statusApi = privateApi.injectEndpoints({
 					name, order, is_active: isActive
 				}
 			}),
-			invalidatesTags: ["Statuses"]
+			invalidatesTags: ["Statuses", "BoardStatuses"]
 		}),
 		updateOrder: builder.mutation<{message: string}, Array<{id: number, order: number}>>({
 			query: (body) => ({
@@ -63,7 +63,7 @@ export const statusApi = privateApi.injectEndpoints({
 					statuses: body 
 				},
 			}),
-			invalidatesTags: ["Statuses"]
+			invalidatesTags: ["Statuses", "BoardStatuses"]
 		}),
 		bulkEditStatuses: builder.mutation<string, Array<Pick<Status, "id" | "isActive">>>({
 			query: (statuses) => ({

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -78,12 +78,14 @@ router.post("/update-order", validateUpdateOrder, handleValidationResult, async 
 		// we get the updated order for the status that was chosen on the frontend,
 		// but we have to find the current status that has this order, and 
 		// "swap" places
-		order = 0
+		let duplicates = new Set()
 		req.body.statuses.forEach((status) => {
-			if (status.order == order){
+			if (duplicates.has(status.order)){
 				res.json({message: "There was an issue while updating orders."}, 422)
 			}
-			order = status.order
+			else {
+				duplicates.add(status.order)
+			}
 		})
 		batchUpdate("statuses", req.body.statuses)
 		res.json({message: "Status orders updated successfully!"})

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -78,6 +78,13 @@ router.post("/update-order", validateUpdateOrder, handleValidationResult, async 
 		// we get the updated order for the status that was chosen on the frontend,
 		// but we have to find the current status that has this order, and 
 		// "swap" places
+		order = 0
+		req.body.statuses.forEach((status) => {
+			if (status.order == order){
+				res.json({message: "There was an issue while updating orders."}, 422)
+			}
+			order = status.order
+		})
 		batchUpdate("statuses", req.body.statuses)
 		res.json({message: "Status orders updated successfully!"})
 


### PR DESCRIPTION
* Invalidate the board status cache after updating the statuses to make sure it pulls the latest updates
* Also added another check on the backend to make sure that both orders are not the same when being sent to the backend.