### PR TITLE
Add Ellipses Menu on Status

### DIFF
--- a/client/src/components/AddTicketForm.tsx
+++ b/client/src/components/AddTicketForm.tsx
@@ -47,10 +47,11 @@ export type FormValues = {
 type Props = {
 	boardId?: number | null | undefined
 	ticket?: Ticket | null | undefined
+	statusId?: number | null | undefined
 	statusesToDisplay?: Array<Status>
 }
 
-export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
+export const AddTicketForm = ({boardId, ticket, statusesToDisplay, statusId}: Props) => {
 	const dispatch = useAppDispatch()
 	const { priorities } = useAppSelector((state) => state.priority)
 	const { statuses } = useAppSelector((state) => state.status)
@@ -71,7 +72,7 @@ export const AddTicketForm = ({boardId, ticket, statusesToDisplay}: Props) => {
 		name: "",
 		description: "",
 		priorityId: 0,
-		statusId: 0,
+		statusId: statusId ?? 0,
 		ticketTypeId: 0,
 		userId: 0 
 	}

--- a/client/src/components/boards/Board.tsx
+++ b/client/src/components/boards/Board.tsx
@@ -15,6 +15,7 @@ import { Ticket } from "../Ticket"
 import { addToast } from "../../slices/toastSlice"
 import { v4 as uuidv4 } from "uuid"
 import { sortStatusByOrder } from "../../helpers/functions"
+import { StatusHeader } from "./StatusHeader"
 
 type Props = {
 	tickets: Array<TicketType>
@@ -25,6 +26,8 @@ type Props = {
 	allStatuses: Array<Status>
 	boardStyle: Record<string, string>
 	colWidth: Record<string, string>
+	addTicketHandler: (statusId: number) => void
+	hideStatusHandler: (statusId: number) => void
 }
 
 export const Board = ({
@@ -36,6 +39,8 @@ export const Board = ({
 	tickets,
 	statusesToDisplay,
 	colWidth,
+	addTicketHandler,
+	hideStatusHandler,
 }: Props) => {
 
 	const dispatch = useAppDispatch()
@@ -80,14 +85,13 @@ export const Board = ({
 					className = "tw-flex tw-flex-col tw-bg-gray-50 tw-min-h-[600px]"
 				>
 					<div>
-						<div className = "tw-ml-2 tw-py-2 tw-flex tw-flex-row tw-items-center tw-gap-x-2">
-							<p className = "tw-font-bold">
-								{allStatuses.find((s: Status) => s.id === status.id)?.name}
-							</p>
-							<span>
-								{board[status.id]?.length}
-							</span>
-						</div>
+						<StatusHeader 
+							statusId={status.id} 
+							numTickets={board[status.id]?.length} 
+							statusName={allStatuses.find((s: Status) => s.id === status.id)?.name ?? ""} 
+							addTicketHandler={addTicketHandler} 
+							hideStatusHandler={hideStatusHandler}
+						/>
 						<div className = "tw-flex tw-flex-col tw-gap-y-2 tw-px-2 tw-pb-2">
 							{board[status.id]?.map((ticketId: number) => {
 								const ticket = tickets.find((t: TicketType) => t.id === ticketId)

--- a/client/src/components/boards/GroupedBoard.tsx
+++ b/client/src/components/boards/GroupedBoard.tsx
@@ -22,6 +22,7 @@ import { LoadingSpinner } from "../LoadingSpinner"
 import { addToast } from "../../slices/toastSlice"
 import { v4 as uuidv4 } from "uuid"
 import { sortStatusByOrder } from "../../helpers/functions"
+import { StatusHeader } from "./StatusHeader"
 
 type Props = {
 	groupedTickets: GroupedTickets
@@ -33,6 +34,8 @@ type Props = {
 	statusesToDisplay: Array<Status>
 	allStatuses: Array<Status>
 	boardStyle: Record<string, string>
+	addTicketHandler: (statusId: number) => void
+	hideStatusHandler: (statusId: number) => void
 }
 
 export const GroupedBoard = ({
@@ -44,7 +47,9 @@ export const GroupedBoard = ({
 	tickets,
 	groupedTickets, 
 	groupBy, 
-	statusesToDisplay
+	statusesToDisplay,
+	addTicketHandler,
+	hideStatusHandler,
 }: Props) => {
 	const dispatch = useAppDispatch()
 	/* object mapping the group by ids to boolean to denote whether the collapse arrow for that section is on/off */
@@ -96,16 +101,13 @@ export const GroupedBoard = ({
 						<div
 						className = "tw-flex tw-flex-col tw-bg-gray-50"
 						>
-							<>
-								<div className = "tw-ml-2 tw-py-2 tw-flex tw-flex-row tw-items-center tw-gap-x-2">
-									<p className = "tw-font-bold">
-										{allStatuses.find((s: Status) => s.id === status.id)?.name}
-									</p>
-									<span>
-										{board[status.id]?.length}
-									</span>
-								</div>
-							</>
+							<StatusHeader 
+								statusId={status.id} 
+								numTickets={board[status.id]?.length} 
+								statusName={allStatuses.find((s: Status) => s.id === status.id)?.name ?? ""} 
+								addTicketHandler={addTicketHandler}
+								hideStatusHandler={hideStatusHandler}
+							/>
 						</div>
 					)
 				})}

--- a/client/src/components/boards/StatusHeader.tsx
+++ b/client/src/components/boards/StatusHeader.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useRef } from "react"
+import { KanbanBoard, Status } from "../../types/common"
+import { useAppDispatch } from "../../hooks/redux-hooks"
+import { IconButton } from "../page-elements/IconButton"
+import { BsThreeDots as MenuIcon } from "react-icons/bs";
+import { useClickOutside } from "../../hooks/useClickOutside" 
+import { IconContext } from "react-icons"
+import { StatusHeaderDropdown } from "./StatusHeaderDropdown"
+
+type Props = {
+	numTickets: number
+	statusId: number
+	statusName: string
+	addTicketHandler: (statusId: number) => void
+	hideStatusHandler: (statusId: number) => void
+}
+
+export const StatusHeader = ({numTickets, statusId, statusName, addTicketHandler, hideStatusHandler}: Props) => {
+	const [ showDropdown, setShowDropdown ] = useState(false)
+	const menuDropdownRef = useRef<HTMLDivElement>(null)
+	const buttonRef = useRef<HTMLButtonElement>(null)
+
+	const onClickOutside = () => {
+		setShowDropdown(false)	
+	}
+
+	useClickOutside(menuDropdownRef, onClickOutside, buttonRef)
+
+	return (
+		<div className = "tw-w-full tw-py-2 tw-flex tw-flex-row tw-items-center tw-space-between">
+			<div className = "tw-pl-2 tw-flex-1 tw-flex tw-flex-row tw-gap-x-2">
+				<p className = "tw-font-bold">
+					{statusName}
+				</p>
+				<span>
+					{numTickets}
+				</span>
+			</div>
+			<div className = "tw-relative tw-inline-block tw-text-left tw-pr-2">
+				<IconContext.Provider value = {{color: "var(--bs-dark-gray"}}>
+					<button ref = {buttonRef} onClick={(e) => {
+						e.preventDefault()
+						setShowDropdown(!showDropdown)
+					}} className = "--transparent tw-p-0 hover:tw-opacity-60"><MenuIcon className = "tw-w-6 tw-h-6"/></button>
+					{
+						showDropdown ? (
+							<StatusHeaderDropdown statusId={statusId} hideStatusHandler={hideStatusHandler} addTicketHandler={addTicketHandler} closeDropdown={onClickOutside} ref = {menuDropdownRef}/>
+						) : null
+					}
+				</IconContext.Provider>
+			</div>
+		</div>
+	)
+}

--- a/client/src/components/boards/StatusHeaderDropdown.tsx
+++ b/client/src/components/boards/StatusHeaderDropdown.tsx
@@ -1,0 +1,52 @@
+import React, { useRef } from "react" 
+import { useAppDispatch, useAppSelector } from "../../hooks/redux-hooks"
+import { Dropdown } from "../Dropdown" 
+import { addToast } from "../../slices/toastSlice"
+import { Toast, Notification } from "../../types/common"
+import { v4 as uuidv4 } from "uuid"
+import { Link, useLocation } from 'react-router-dom';
+import { NOTIFICATIONS } from "../../helpers/routes"
+
+type Props = {
+	closeDropdown: () => void
+	statusId: number
+	addTicketHandler: (statusId: number) => void
+	hideStatusHandler: (statusId: number) => void
+}
+
+export const StatusHeaderDropdown = React.forwardRef<HTMLDivElement, Props>(({closeDropdown, statusId, addTicketHandler, hideStatusHandler}: Props, ref) => {
+	const dispatch = useAppDispatch()
+
+	const options = {
+		"Add Ticket": () => {
+			addTicketHandler(statusId)
+		},
+		"Set Column Limit": () => {
+			console.log("Placeholder for set limit")
+		},
+		"Hide Column": () => {
+			hideStatusHandler(statusId)
+		},
+	}
+
+	return (
+		<Dropdown ref = {ref}>
+			<ul>
+				{Object.keys(options).map((option) => (
+					<li
+						key={option}
+						onClick={() => {
+							options[option as keyof typeof options]?.()
+							closeDropdown()
+						}}
+						className="tw-block hover:tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700 tw-hover:bg-gray-100 tw-hover:text-gray-900"
+						role="menuitem"
+					>
+						{option}
+					</li>
+				))}			
+			</ul>
+		</Dropdown>
+	)	
+})
+

--- a/client/src/components/boards/ToolBar.tsx
+++ b/client/src/components/boards/ToolBar.tsx
@@ -103,7 +103,7 @@ export const ToolBar = () => {
 						dispatch(setModalType("BOARD_STATUS_FORM"))
 					}}>Edit Statuses</button>) : null
 				}
-				<button className = "button" onClick = {(e) => prioritySort(1)}>Sort By Priority</button>
+				{/*<button className = "button" onClick = {(e) => prioritySort(1)}>Sort By Priority</button>*/}
 				<div className = "tw-flex tw-flex-col lg:tw-flex-row lg:tw-items-center tw-gap-y-2 lg:tw-gap-x-2">
 					<label className = "label" htmlFor="board-group-by">Group By</label>
 					<select 

--- a/client/src/components/primary-modals/AddTicketFormModal.tsx
+++ b/client/src/components/primary-modals/AddTicketFormModal.tsx
@@ -7,10 +7,11 @@ type Props = {
 	statusesToDisplay?: Array<Status>
 	ticket?: Ticket | null | undefined
 	boardId?: number | null | undefined
+	statusId?: number | null | undefined
 }
 
-export const AddTicketFormModal = ({boardId, ticket, statusesToDisplay}: Props) => {
+export const AddTicketFormModal = ({boardId, ticket, statusesToDisplay, statusId}: Props) => {
 	return (
-		<AddTicketForm boardId={boardId} ticket={ticket} statusesToDisplay={statusesToDisplay}/>
+		<AddTicketForm boardId={boardId} ticket={ticket} statusesToDisplay={statusesToDisplay} statusId={statusId}/>
 	)	
 }


### PR DESCRIPTION
* Add on each status header on the board, add an ellipses menu that displays a dropdown with the ability to add ticket and hide the status. 
* When adding a ticket this way, it will pre-populate the status dropdown with the same status that was clicked
* There's also a placeholder for setting column limit but that hasn't been implemented yet.


https://github.com/user-attachments/assets/11ee5e2d-1ae1-4d43-86a6-9dcd61544dfb

