### PR TITLE
Dashboard progress and time spent and `is_completed` on add/edit status

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -4,7 +4,7 @@ import "../styles/dashboard.css"
 import { useNavigate, useLocation, Link } from "react-router-dom" 
 import { useGetUserOrganizationsQuery, useSwitchUserOrganizationMutation } from "../services/private/userProfile"
 import { useGetTicketsQuery } from "../services/private/ticket"
-import { Ticket, Organization, Toast, OptionType } from "../types/common"
+import { Ticket, Organization, Toast, OptionType, ProgressBarPercentage } from "../types/common"
 import { setCredentials } from "../slices/authSlice"
 import { logout } from "../slices/authSlice" 
 import { privateApi } from "../services/private" 
@@ -15,6 +15,7 @@ import { GroupBase, SelectInstance } from "react-select"
 import { USER_PROFILE_ORG_URL } from "../helpers/urls"
 import { PaginationRow } from "./page-elements/PaginationRow"
 import { TicketRow } from "./TicketRow" 
+import { ProgressBar } from "./page-elements/ProgressBar"
 import { TICKETS, BOARDS } from "../helpers/routes"
 import { Banner } from "./page-elements/Banner"
 import { TicketsContainer } from "./tickets/TicketsContainer"
@@ -25,6 +26,7 @@ import { LuClock as ClockIcon } from "react-icons/lu";
 import { BsFillFileBarGraphFill as BarsIcon } from "react-icons/bs";
 import { IconContext } from "react-icons"
 import { FaRegBuilding } from "react-icons/fa";
+import { convertMinutesToTimeDisplay } from "../helpers/functions"
 
 type DashboardSectionProps = {
 	title: string
@@ -63,6 +65,24 @@ export const Dashboard = () => {
 	const {data: watchedTickets, isLoading: isWatchedTicketsLoading} = useGetTicketsQuery(Object.keys(watchSearchParams).length > 0 ? watchSearchParams : skipToken)
 	const {data: boards, isLoading: isBoardsLoading} = useGetBoardsQuery({includeUserDashboardInfo: true, perPage: 5})
 	const selectRef = useRef<SelectInstance<OptionType, false, GroupBase<OptionType>>>(null) 
+
+	// extract the remaining dashboard info into separate array of objects for
+	// easier display on the dashboard
+	const timeSpentPerBoard = boards?.data?.map((board) => {
+		return {
+			id: board.id,
+			minutesSpent: board.minutesSpent ? convertMinutesToTimeDisplay(board.minutesSpent, false, true) : ""
+		}	
+	})
+	const percentageCompletePerBoard = boards?.data?.map((board) => {
+		return {
+			id: board.id,
+			percentComplete: [
+				{className: "tw-bg-primary", label: "Completed", value: board.percentComplete ?? 0},
+				{className: "tw-bg-secondary", label: "Not Completed", value: 100 - (board.percentComplete ?? 0)},
+			]	
+		}	
+	})
 
 	useEffect(() => {
 		if (userProfile){
@@ -167,10 +187,24 @@ export const Dashboard = () => {
 						</div>	
 					</DashboardSection>
 					<DashboardSection iconColor={"var(--bs-warning)"} icon={<BarsIcon/>} title={"Progress"}>
-						<div></div>
+						<div className = "tw-flex tw-flex-col tw-gap-y-2">
+							{
+								percentageCompletePerBoard?.map((board) => (
+									<div className = "tw-flex tw-flex-row tw-items-center tw-min-h-[24px]">
+										<ProgressBar percentages = {board.percentComplete}/> 
+									</div>
+								))
+							}	
+						</div>
 					</DashboardSection>
 					<DashboardSection iconColor={"var(--bs-success)"} icon={<ClockIcon/>} title={"Time Spent"}>
-						<div></div>
+						<div className = "tw-flex tw-flex-col tw-gap-y-2">
+							{
+								timeSpentPerBoard?.map((board) => (
+									<div>{board.minutesSpent}</div>
+								))
+							}
+						</div>
 					</DashboardSection>
 				</div>
 			</div>

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -61,7 +61,7 @@ export const Dashboard = () => {
 	const [watchSearchParams, setWatchSearchParams] = useState<Record<string, any>>({})
 	const {data: assignedTickets, isLoading: isAssignedTicketsLoading} = useGetTicketsQuery(Object.keys(assignedSearchParams).length > 0 ? assignedSearchParams : skipToken)
 	const {data: watchedTickets, isLoading: isWatchedTicketsLoading} = useGetTicketsQuery(Object.keys(watchSearchParams).length > 0 ? watchSearchParams : skipToken)
-	const {data: boards, isLoading: isBoardsLoading} = useGetBoardsQuery({boardTicketAssignee: userProfile?.id, perPage: 5})
+	const {data: boards, isLoading: isBoardsLoading} = useGetBoardsQuery({includeUserDashboardInfo: true, perPage: 5})
 	const selectRef = useRef<SelectInstance<OptionType, false, GroupBase<OptionType>>>(null) 
 
 	useEffect(() => {

--- a/client/src/components/page-elements/ProgressBar.tsx
+++ b/client/src/components/page-elements/ProgressBar.tsx
@@ -8,7 +8,7 @@ type Props = {
 export const ProgressBar = ({percentages}: Props) => {
 	return (
 		// overflow-hidden must be added so the colored bars do not overflow on top of the rounded borders
-		<div className = "tw-mb-4 tw-rounded-md tw-overflow-hidden tw-bg-gray-100 tw-w-full tw-h-2.5 tw-flex tw-flex-row">
+		<div className = "tw-rounded-md tw-overflow-hidden tw-bg-gray-100 tw-w-full tw-h-2.5 tw-flex tw-flex-row">
 			{percentages.map((percentage: ProgressBarPercentage, i: number) => {
 				if (percentage.value > 0){
 					return (

--- a/client/src/components/primary-modals/OrganizationStatusModal.tsx
+++ b/client/src/components/primary-modals/OrganizationStatusModal.tsx
@@ -22,6 +22,7 @@ type FormValues = {
 	id?: number
 	name: string
 	isActive: boolean
+	isCompleted: boolean
 }
 
 export const OrganizationStatusModal = () => {
@@ -38,7 +39,8 @@ export const OrganizationStatusModal = () => {
 	const defaultForm: FormValues = {
 		id: undefined,
 		name: "",
-		isActive: false
+		isActive: false,
+		isCompleted: false,
 	}
 	const [preloadedValues, setPreloadedValues] = useState<FormValues>(defaultForm)
 	const { register , handleSubmit, reset , setValue, getValues, formState: {errors} } = useForm<FormValues>({
@@ -58,13 +60,23 @@ export const OrganizationStatusModal = () => {
 				}
 				<div className = {`tw-flex tw-flex-col tw-gap-y-2`}>
 					<div className = "">
-						<label className = "label">Name</label>
-						<input type = "text" {...register("name")}/>
+						<label htmlFor = "status-name" className = "label">Name</label>
+						<input id = "status-name" type = "text" {...register("name")}/>
 				        {errors?.name && <small className = "--text-alert">{errors.name.message}</small>}
 					</div>
 					<div className = "tw-flex tw-flex-row tw-gap-x-2">
-						<input type = "checkbox" {...register("isActive")}/>
-						<label className = "label">Is Active</label>	
+						<input id = "status-is-active" type = "checkbox" {...register("isActive")}/>
+						<label htmlFor = "status-is-active" className = "label">Is Active</label>	
+					</div>
+					<div>
+						<small><span className = "tw-font-bold">*</span>check this off to display this status across all boards in this organization</small>	
+					</div>
+					<div className = "tw-flex tw-flex-row tw-gap-x-2">
+						<input id = "status-is-completed" type = "checkbox" {...register("isCompleted")}/>
+						<label htmlFor = "status-is-completed" className = "label">Is Completed</label>	
+					</div>
+					<div>
+						<small><span className = "tw-font-bold">*</span>check this off so that all tickets in this status are considered "completed" for progress checking purposes</small>	
 					</div>
 					<div>
 						<button type = "submit" className = "button">Save</button>
@@ -183,7 +195,8 @@ export const OrganizationStatusModal = () => {
 		reset({
 			id: undefined,	
 			name: "",
-			isActive: false
+			isActive: false,
+			isCompleted: false,
 		})
 		setSelectedStatusId(null)
 	}		
@@ -199,7 +212,8 @@ export const OrganizationStatusModal = () => {
 						reset({
 							id: undefined,	
 							name: "",
-							isActive: false
+							isActive: false,
+							isCompleted: false,
 						})
 					}} className = "button --secondary">
 						<div className = "tw-flex tw-items-center tw-gap-x-2">
@@ -224,6 +238,7 @@ export const OrganizationStatusModal = () => {
 									id: status.id,	
 									name: status.name,
 									isActive: status.isActive,
+									isCompleted: status.isCompleted,
 								})
 							}} key = {status.id} className = "button">
 								{status.name}

--- a/client/src/components/secondary-modals/DeleteTicketActivityWarning.tsx
+++ b/client/src/components/secondary-modals/DeleteTicketActivityWarning.tsx
@@ -35,7 +35,7 @@ export const DeleteTicketActivityWarning = ({ticketId, activityId}: DeleteTicket
 				closeSecondaryModal()
 				dispatch(addToast({
 					...defaultToast, 
-					message: "activity deleted successfully!",
+					message: "Activity deleted successfully!",
 					type: "success",
 				}))
 			}
@@ -63,7 +63,7 @@ export const DeleteTicketActivityWarning = ({ticketId, activityId}: DeleteTicket
 				cancelText={"Cancel"}
 			>
 				<div className = "tw-py-4">
-					<strong>Are you sure you want to delete this ticket Activity?</strong>
+					<strong>Are you sure you want to delete this ticket activity?</strong>
 				</div>
 			</Warning>
 		</div>

--- a/client/src/services/private/status.ts
+++ b/client/src/services/private/status.ts
@@ -7,6 +7,7 @@ import { privateApi } from "../private"
 type AddStatusRequest = {
 	name: string
 	isActive: boolean
+	isCompleted: boolean
 	order: number	
 }
 
@@ -34,23 +35,24 @@ export const statusApi = privateApi.injectEndpoints({
 			providesTags: ["Statuses"]
 		}),
 		addStatus: builder.mutation<{message: string}, AddStatusRequest>({
-			query: ({name, order, isActive}) => ({
+			query: ({name, order, isActive, isCompleted}) => ({
 				url: STATUS_URL,
 				method: "POST",
 				body: {
 					name,
 					order,
-					is_active: isActive
+					is_active: isActive,
+					is_completed: isCompleted,
 				}
 			}),
 			invalidatesTags: ["Statuses", "BoardStatuses"]
 		}),
 		updateStatus: builder.mutation<{message: string}, UpdateStatusRequest>({
-			query: ({id, name, order, isActive}) => ({
+			query: ({id, name, order, isActive, isCompleted}) => ({
 				url: `${STATUS_URL}/${id}`,
 				method: "PUT",
 				body: {
-					name, order, is_active: isActive
+					name, order, is_active: isActive, is_completed: isCompleted,
 				}
 			}),
 			invalidatesTags: ["Statuses", "BoardStatuses"]

--- a/client/src/types/common.ts
+++ b/client/src/types/common.ts
@@ -74,6 +74,8 @@ export interface Board {
 	organizationId: number
 	lastModified?: Date
 	assignees?: Array<number>
+	minutesSpent?: number
+	percentComplete?: number
 }
 
 export interface Ticket {

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -79,26 +79,44 @@ router.get("/", async (req, res, next) => {
 			numTicketsRes = mapIdToRowObject(numTickets)
 		}
 
-		let percentComplete;
+		let dashboardInfoMap = {}
 		if (req.query.includeUserDashboardInfo === "true"){
-			// assignedTickets
-			assignedTicketsWithStatuses = await db("boards").where("boards.organization_id", req.user.organization).whereIn("boards.id", boards.data.map((b) => b.id))
+			assignedTickets = await db("boards").where("boards.organization_id", req.user.organization).whereIn("boards.id", boards.data.map((b) => b.id))
 			.join("tickets_to_boards", "tickets_to_boards.board_id", "=", "boards.id")
 			.join("tickets_to_users", "tickets_to_users.ticket_id", "=", "tickets_to_boards.ticket_id")
 			.join("tickets", "tickets_to_boards.ticket_id", "=", "tickets.id")
+			.leftJoin("ticket_activity", "tickets_to_boards.ticket_id", "=", "ticket_activity.ticket_id")
+			.sum("ticket_activity.minutes_spent as minutesSpent")
+			.groupBy("tickets.id")
 			.where("tickets_to_users.user_id", "=", req.user.id)
 			.where("tickets_to_users.is_watcher", false)
 			.where("tickets_to_users.is_mention", false)
 			.select(
 				"boards.id as id",
 				"tickets.id as ticketId",
-				"tickets.status_id as statusId"
+				"tickets.status_id as statusId",
 			)
-			percentComplete = mapIdToRowAggregateObjArray(assignedTicketsWithStatuses, ["ticketId", "statusId"])
-			console.log(percentComplete)
+			/* 
+				map the board id to the ticket information
+				'13': [ { ticketId: 198, statusId: 8, minutesSpent: null }, { ticketId: 188, statusId: 7, minutesSpent: 360 } ],
+				'14': [ { ticketId: 181, statusId: 7, minutesSpent: null }, { ticketId: 185, statusId: 7, minutesSpent: null } ]
+			*/
+			const boardsToAssignedTickets = mapIdToRowAggregateObjArray(assignedTickets, ["ticketId", "statusId", "minutesSpent"])
+			const allIsCompleteStatuses = await db("statuses").where("is_completed", true).where("organization_id", req.user.organization)
+			const statusIds = allIsCompleteStatuses.map((status) => status.id)
+			Object.keys(boardsToAssignedTickets).forEach((boardId) => {
+				const numTicketsCompletedByUser = boardsToAssignedTickets[boardId].filter((ticket) => statusIds.includes(ticket.statusId)).length
+				const allTickets = boardsToAssignedTickets[boardId].length
+				const percentComplete = Math.floor((numTicketsCompletedByUser/allTickets) * 100)
+				const totalMinutesSpent = boardsToAssignedTickets[boardId].reduce((acc, obj) => {
+					return acc + obj.minutesSpent
+				}, 0)
+				dashboardInfoMap[boardId] = {minutesSpent: totalMinutesSpent, percentComplete: percentComplete}
+			})
+
 		}
 
-		if (req.query.lastModified === "true" || req.query.assignees === "true" || req.query.numTickets === "true"){
+		if (req.query.lastModified === "true" || req.query.assignees === "true" || req.query.numTickets === "true" || req.query.includeUserDashboardInfo){
 			resData = boards.data.map((board) => {
 				let lastUpdated;
 				if (req.query.lastModified === "true"){
@@ -109,6 +127,12 @@ router.get("/", async (req, res, next) => {
 					name: board.name,
 					organizationId: board.organizationId,
 					...(req.query.lastModified === "true" ? {lastModified: lastUpdated ?? null} : {})
+				}
+				if (req.query.includeUserDashboardInfo){
+					boardRes = {...boardRes,
+						percentComplete: dashboardInfoMap[board.id].percentComplete ?? 0,
+						minutesSpent: dashboardInfoMap[board.id].minutesSpent ?? 0
+					}
 				}
 				if (req.query.assignees === "true" && board.id in boardAssigneesRes){
 					boardRes = {...boardRes, assignees: Object.keys(boardAssigneesRes).length > 0 ? boardAssigneesRes[board.id] : 0}

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -48,6 +48,7 @@ router.post("/", validateCreate, handleValidationResult, async (req, res, next) 
 			name: body.name,
 			order: body.order,
 			is_active: req.body.is_active,
+			is_completed: req.body.is_completed,
 			organization_id: body.organization_id
 		}, ["id"])
 		res.json({id: id[0], message: `Status inserted successfully!`})
@@ -63,6 +64,7 @@ router.put("/:id", validateUpdate, handleValidationResult, async (req, res, next
 		await db("statuses").where("id", req.params.id).update({
 			name: req.body.name,
 			is_active: req.body.is_active,
+			is_completed: req.body.is_completed,
 			order: req.body.order,
 		})
 		res.json({message: "Status updated successfully!"})	


### PR DESCRIPTION
* Display the logged in users' progress on their assigned tickets per board, as well as the total time spent on their assigned tickets per board
* Also added the `is_completed` field on the add edit statuses page for admin

![NVIDIA_Overlay_ZBOoPsbunu](https://github.com/user-attachments/assets/cd0cd330-f188-462e-9628-988690a26742)
