### PR TITLE
Add Notification Types for new users + assignee notification bug fix

### DIFF
--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -221,7 +221,9 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
     			if (values.userId){
 	    			await bulkEditTicketAssignees({ticketId: values.id, userIds: [values.userId], isWatcher: false}).unwrap()
     			}
-    			if (values.userId && userProfile && values.userId !== userProfile.id && assigneeNotificationType){
+    			// if the assignee id was changed from its previous value, and it's not equal to the logged in user,
+    			// send notification
+    			if (values.userId && values.userId !== ticketAssignees?.[0]?.id && userProfile && values.userId !== userProfile.id && assigneeNotificationType){
     				await addNotification({
     					recipientId: values.userId,
     					senderId: userProfile.id,

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -59,6 +59,12 @@ router.post("/register", userValidator.registerValidator, handleValidationResult
 			user_id: user[0],
 			organization_id: req.body.organization_id
 		})
+
+		// insert all notification types by default for a user
+		const notificationTypes = await db("notification_types")
+		const userToNotificationTypes = notificationTypes.map((notification) => ({user_id: user[0], notification_type_id: notification.id}))	
+		await db("users_to_notification_types").insert(userToNotificationTypes)
+
 		const organization = await db("organizations").where("id", req.body.organization_id).first()
 
 		// TODO: send this to an async queue so the request isn't held up by email sending


### PR DESCRIPTION
Newly registered users will now have all notification types added
Also fixed an issue where the assignee notification would be sent even when no change to the assignee was made when editing a ticket.