### PR TITLE
Add profile image on admin users page

### DIFF
--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -80,6 +80,16 @@ export const Table = ({config, data, itemIds, tableKey: tKey, hideCheckAllBox}: 
 												</td>
 											)
 										}
+										else if (config.renderers && headerKey in config.renderers){
+											const {component: Component, props} = config.renderers[headerKey](row[headerKey])
+											return (
+												<td key = {`${tableKey}-${row.id}-${headerKey}`}>
+													<div className = "tw-flex tw-justify-center">
+														<Component {...props}/>
+													</div>
+												</td>
+											)
+										}
 										else if (headerKey in config.modifiers){
 											const {modifier, lookup} = config.modifiers[headerKey]
 											return (

--- a/client/src/helpers/table-config/useUserProfileConfig.ts
+++ b/client/src/helpers/table-config/useUserProfileConfig.ts
@@ -6,10 +6,12 @@ import { Toast, UserRegistrationRequest } from "../../types/common"
 import { useBulkEditRegistrationRequestsMutation, useUpdateRegistrationRequestMutation } from "../../services/private/organization"
 import { addToast } from "../../slices/toastSlice"
 import { v4 as uuidv4 } from "uuid"
+import { Avatar } from "../../components/page-elements/Avatar"
 
 export type useUserProfileConfigType = {
-	headers: Record<string, any>,
+	headers: Record<string, any>
 	modifiers: Record<string, any>
+	renderers: Record<string, any>
 	bulkEdit: Record<string, any>
 	editCol: Record<string, any>
 }
@@ -21,6 +23,7 @@ export const useUserProfileConfig = () => {
 	const isAdminOrBoardAdmin = userProfile && (userRoleLookup[userProfile.userRoleId] === "ADMIN" || userRoleLookup[userProfile.userRoleId] === "BOARD_ADMIN")
 	return {
 		headers: {
+			"imageUrl": "",
 			"firstName": "First Name", 
 			"lastName": "Last Name", 
 			"email": "Email", 
@@ -29,6 +32,18 @@ export const useUserProfileConfig = () => {
 		},
 		modifiers: {
 			"userRoleId": { modifier: userRoleModifier, lookup: userRoleLookup },
+		},
+		renderers: {
+			imageUrl: (url: string) => {
+				return {
+					component: Avatar,
+					props: {
+						imageUrl: url,
+						size: "m",	
+						className: "tw-rounded-full",
+					}
+				}
+			}
 		},
 		editCol: {
 			col: "edit", 


### PR DESCRIPTION
* Added a custom renderers section on the table config to display a component with one custom prop that comes from the table attribute. 
* For example, the "imageUrl" attribute serves as a prop to display the image within the `<Avatar/>` component.
* Will need to consider a different method if a component requires multiple props that are custom per table row.

<img width="993" alt="Screenshot 2025-03-20 at 5 05 25 PM" src="https://github.com/user-attachments/assets/a4ed6674-d0b4-4d90-b6ee-99f3f695981e" />
