### PR TITLE
Fix `react-scripts` and `react-icons` build errors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,9 @@
     "uuid": "^9.0.1",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "typescript": "^5.8.2"
+  },
   "scripts": {
     "dev": "set PORT=3006 && react-scripts start",
     "start": "serve -s build",

--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from "react"
 import { IconContext } from "react-icons"
 import { CgProfile } from "react-icons/cg"
 import { HiOutlineLink as LinkIcon } from "react-icons/hi";
+import { IconLink } from "./icons/IconLink"
 import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks"
 import { setModalType } from "../slices/modalSlice" 
 import { LoadingSpinner } from "./LoadingSpinner"
@@ -28,6 +29,7 @@ import { EditTicketFormToolbar } from "./EditTicketFormToolbar"
 import { priorityIconMap, PriorityIcon, TicketTypeIcon , colorMap } from "./Ticket"
 import { EditTicketFormMenuDropdown } from "./dropdowns/EditTicketFormMenuDropdown" 
 import { ImTree as AddToEpicIcon } from "react-icons/im";
+import { IconTree } from "./icons/IconTree"
 import { Badge } from "./page-elements/Badge"
 import { PaginationRow } from "./page-elements/PaginationRow"
 import { Link } from "react-router-dom"
@@ -576,9 +578,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 									setShowAddLinkedIssue(!showAddLinkedIssue)
 								}} className = "button !tw-bg-secondary">
 									<div className = "icon-container">
-										<IconContext.Provider value = {{className: "icon"}}>
-											<LinkIcon/>
-										</IconContext.Provider>
+										<IconLink className="icon"/>
 										<span>Link Issue</span>
 									</div>
 								</button>
@@ -590,9 +590,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 										setShowAddToEpic(!showAddToEpic)
 										}} className = "button !tw-bg-light-purple">
 											<div className = "icon-container">
-												<IconContext.Provider value = {{className: "icon"}}>
-													<AddToEpicIcon/>
-												</IconContext.Provider>
+												<IconTree className="icon"/>
 												<span>Add To Epic</span>
 											</div>
 										</button>

--- a/client/src/components/EditTicketFormToolbar.tsx
+++ b/client/src/components/EditTicketFormToolbar.tsx
@@ -3,9 +3,10 @@ import { useAppDispatch, useAppSelector } from "../hooks/redux-hooks"
 import { IconContext } from "react-icons" 
 import { EditTicketFormMenuDropdown } from "./dropdowns/EditTicketFormMenuDropdown"
 import { WatchMenuDropdown } from "./dropdowns/WatchMenuDropdown"
-import { IoMdEye as WatchIcon, IoMdEyeOff as WatchOffIcon } from "react-icons/io";
+import { IconMenu } from "./icons/IconMenu"
+import { IconEye } from "./icons/IconEye"
 import { BsThreeDots as MenuIcon } from "react-icons/bs";
-import { FiShare2 as ShareIcon } from "react-icons/fi";
+import { IconShare } from "./icons/IconShare"
 import { useClickOutside } from "../hooks/useClickOutside" 
 import { Ticket, Status, UserProfile } from "../types/common"
 import { TICKETS } from "../helpers/routes"
@@ -60,7 +61,7 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 						setShowWatchDropdown(!showWatchDropdown)
 					}}>
 						<div className = "tw-flex tw-flex-row tw-gap-x-1 tw-items-center">
-							<WatchIcon className = "tw-ml-3 --l-icon"/>
+							<IconEye className = "tw-ml-3 --l-icon"/>
 							{
 								(ticketWatchers && ticketWatchers?.length > 0 ? (
 									<span className = "tw-text-primary">{ticketWatchers.length}</span>
@@ -87,7 +88,7 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 						animationType: "animation-in"
 					}))
 				}}>
-					<ShareIcon className = "tw-ml-3 --l-icon"/>
+					<IconShare className = "tw-ml-3 --l-icon"/>
 				</button>
 			</IconContext.Provider>
 			<div className = "tw-relative tw-inline-block tw-text-left">
@@ -95,7 +96,7 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 					<button ref = {buttonRef} onClick={(e) => {
 						e.preventDefault()
 						setShowDropdown(!showDropdown)
-					}} className = "--transparent tw-p-0 hover:tw-opacity-60"><MenuIcon className = "tw-ml-3 --l-icon"/></button>
+					}} className = "--transparent tw-p-0 hover:tw-opacity-60"><IconMenu className = "tw-ml-3 --l-icon"/></button>
 					{
 						showDropdown ? (
 							<EditTicketFormMenuDropdown closeDropdown={onClickOutside} statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>

--- a/client/src/components/EditTicketFormToolbar.tsx
+++ b/client/src/components/EditTicketFormToolbar.tsx
@@ -55,54 +55,47 @@ export const EditTicketFormToolbar = ({statusesToDisplay, ticket, ticketAssignee
 	return (
 		<div className = "tw-pt-2 tw-pb-2 tw-flex tw-flex-row tw-justify-end tw-w-full">
 			<div className = "tw-relative tw-inline-block tw-text-left">
-				<IconContext.Provider value = {{color: "var(--bs-primary)"}}>
-					<button className = "hover:tw-opacity-60" ref = {watchButtonRef} onClick={(e) => {
-						e.preventDefault()	
-						setShowWatchDropdown(!showWatchDropdown)
-					}}>
-						<div className = "tw-flex tw-flex-row tw-gap-x-1 tw-items-center">
-							<IconEye className = "tw-ml-3 --l-icon"/>
-							{
-								(ticketWatchers && ticketWatchers?.length > 0 ? (
-									<span className = "tw-text-primary">{ticketWatchers.length}</span>
-								) : null)
-							}
-						</div>
-					</button>
-					
-				</IconContext.Provider>
+				<button className = "hover:tw-opacity-60" ref = {watchButtonRef} onClick={(e) => {
+					e.preventDefault()	
+					setShowWatchDropdown(!showWatchDropdown)
+				}}>
+					<div className = "tw-flex tw-flex-row tw-gap-x-1 tw-items-center">
+						<IconEye color={"var(--bs-primary"} className = "tw-ml-3 --l-icon"/>
+						{
+							(ticketWatchers && ticketWatchers?.length > 0 ? (
+								<span className = "tw-text-primary">{ticketWatchers.length}</span>
+							) : null)
+						}
+					</div>
+				</button>
 				{
 					showWatchDropdown ? (
 						<WatchMenuDropdown closeDropdown={onClickWatchOutside} ticketAssignee={ticketAssignee} ticketWatchers={ticketWatchers} ticket={ticket} ref = {watchMenuDropdownRef}/>
 					) : null
 				}
 			</div>
-			<IconContext.Provider value = {{color: "var(--bs-primary)"}}>
-				<button className = "hover:tw-opacity-60" onClick={(e) => {
-					e.preventDefault()	
-					navigator.clipboard.writeText(`${window.location.origin}${TICKETS}/${ticket?.id}`)
-					dispatch(addToast({
-						id: uuidv4(),
-						type: "success",
-						message: "Link copied to clipboard",
-						animationType: "animation-in"
-					}))
-				}}>
-					<IconShare className = "tw-ml-3 --l-icon"/>
-				</button>
-			</IconContext.Provider>
+			<button className = "hover:tw-opacity-60" onClick={(e) => {
+				e.preventDefault()	
+				navigator.clipboard.writeText(`${window.location.origin}${TICKETS}/${ticket?.id}`)
+				dispatch(addToast({
+					id: uuidv4(),
+					type: "success",
+					message: "Link copied to clipboard",
+					animationType: "animation-in"
+				}))
+			}}>
+				<IconShare color = {"var(--bs-primary"} className = "tw-ml-3 --l-icon"/>
+			</button>
 			<div className = "tw-relative tw-inline-block tw-text-left">
-				<IconContext.Provider value = {{color: "var(--bs-dark-gray"}}>
-					<button ref = {buttonRef} onClick={(e) => {
-						e.preventDefault()
-						setShowDropdown(!showDropdown)
-					}} className = "--transparent tw-p-0 hover:tw-opacity-60"><IconMenu className = "tw-ml-3 --l-icon"/></button>
-					{
-						showDropdown ? (
-							<EditTicketFormMenuDropdown closeDropdown={onClickOutside} statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>
-						) : null
-					}
-				</IconContext.Provider>
+				<button ref = {buttonRef} onClick={(e) => {
+					e.preventDefault()
+					setShowDropdown(!showDropdown)
+				}} className = "--transparent tw-p-0 hover:tw-opacity-60"><IconMenu color={"var(--bs-dark-grey)"} className = "tw-ml-3 --l-icon"/></button>
+				{
+					showDropdown ? (
+						<EditTicketFormMenuDropdown closeDropdown={onClickOutside} statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>
+					) : null
+				}
 			</div>
 		</div>
 	)

--- a/client/src/components/EditUserForm.tsx
+++ b/client/src/components/EditUserForm.tsx
@@ -10,6 +10,8 @@ import { UserProfile } from "../types/common"
 import { parseDelimitedWord } from "../helpers/functions"
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { FaEye, FaEyeSlash } from "react-icons/fa"
+import { IconEye } from "./icons/IconEye"
+import { IconEyeSlash } from "./icons/IconEyeSlash"
 import { PasswordRules } from "./page-elements/PasswordRules"
 import { LoadingSkeleton } from "./page-elements/LoadingSkeleton"
 import { ColumnFormPlaceholder } from "./placeholders/ColumnFormPlaceholder"
@@ -236,8 +238,8 @@ export const EditUserForm = ({userId, isAccountsPage, isChangePassword}: Props) 
 									/>
 									{
 										!showPassword ? 
-										<FaEye className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4" onClick={() => setShowPassword(!showPassword)}/> : 
-										<FaEyeSlash className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4" onClick={() => setShowPassword(!showPassword)}/>
+										<button onClick={() => setShowPassword(!showPassword)}><IconEye className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4" /></button> :
+										<button onClick={() => setShowPassword(!showPassword)}><IconEyeSlash className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4"/></button>
 									}
 								</div>
 						        {errors?.confirmPassword && <small className = "--text-alert">{errors.confirmPassword.message}</small>}

--- a/client/src/components/Ticket.tsx
+++ b/client/src/components/Ticket.tsx
@@ -8,6 +8,7 @@ import { HiChevronDown as LowPriorityIcon } from "react-icons/hi2";
 import { IconLowPriority } from "./icons/IconLowPriority"
 import { IconMediumPriority } from "./icons/IconMediumPriority"
 import { IconHighPriority } from "./icons/IconHighPriority"
+import { IconMenu } from "./icons/IconMenu"
 import { IconContext } from "react-icons"
 import { BugIcon } from "../assets/icons/BugIcon"
 import { ModificationIcon } from "../assets/icons/ModificationIcon"
@@ -137,7 +138,7 @@ export const Ticket = ({ticket, boardId, statusesToDisplay, dropdownAlignLeft}: 
 							// when clicking the "..." menu on the individual ticket rather than from inside the edit ticket form modal
 							e.preventDefault()
 							setShowDropdown(!showDropdown)
-						}} className = "--transparent tw-p-0 hover:tw-opacity-60"><MenuIcon className = "tw-ml-3 tw-w-4 tw-h-4"/></button>
+						}} className = "--transparent tw-p-0 hover:tw-opacity-60"><IconMenu className = "tw-ml-3 tw-w-4 tw-h-4"/></button>
 						{
 							showDropdown ? (
 								<EditTicketFormMenuDropdown dropdownAlignLeft={dropdownAlignLeft} closeDropdown={onClickOutside} statusesToDisplay={statusesToDisplay} boardId={boardId} ticket={ticket} ref = {menuDropdownRef}/>

--- a/client/src/components/dropdowns/WatchMenuDropdown.tsx
+++ b/client/src/components/dropdowns/WatchMenuDropdown.tsx
@@ -5,7 +5,8 @@ import { toggleShowSecondaryModal, setSecondaryModalProps, setSecondaryModalType
 import { Toast, Ticket, Status, UserProfile } from "../../types/common"
 import { CgProfile } from "react-icons/cg"
 import { Avatar } from "../page-elements/Avatar"
-import { IoMdEye as WatchIcon, IoMdEyeOff as WatchOffIcon } from "react-icons/io";
+import { IconEye } from "../icons/IconEye";
+import { IconEyeSlash } from "../icons/IconEyeSlash";
 import { 
 	useAddTicketAssigneeMutation,
 	useDeleteTicketAssigneeMutation, 
@@ -135,8 +136,8 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({isMob
 							>
 								<div className = "tw-flex tw-flex-row tw-gap-x-2">
 									{option === "Start Watching" ? 
-									<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>
-									: <div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><WatchOffIcon className = "tw-w-6 tw-h-6"/><p>{option}</p></div>}
+									<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><IconEye className = "tw-w-6 tw-h-6"/><p>{option}</p></div>
+									: <div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center"><IconEyeSlash className = "tw-w-6 tw-h-6"/><p>{option}</p></div>}
 								</div>
 							</li>
 						)

--- a/client/src/components/forms/AddEditStatusForm.tsx
+++ b/client/src/components/forms/AddEditStatusForm.tsx
@@ -15,8 +15,11 @@ import { useForm, Controller } from "react-hook-form"
 import { v4 as uuidv4 } from "uuid"
 import { LoadingSpinner } from "../LoadingSpinner"
 import { IoIosArrowDown as ArrowDown, IoIosArrowUp as ArrowUp } from "react-icons/io";
+import { IconArrowUp } from "../icons/IconArrowUp"
+import { IconArrowDown } from "../icons/IconArrowDown"
 import { IconButton } from "../page-elements/IconButton"
 import { IoMdAdd as AddIcon } from "react-icons/io";
+import { IconPlus } from "../icons/IconPlus"
 import { Switch } from "../page-elements/Switch"
 import { RowContentLoading } from "../page-elements/RowContentLoading"
 
@@ -244,7 +247,7 @@ export const AddEditStatusForm = () => {
 						})
 					}} className = "button --secondary">
 						<div className = "tw-flex tw-items-center tw-gap-x-2">
-							<AddIcon/>
+							<IconPlus/>
 							<p>Add Status</p>
 						</div>
 					</button>
@@ -271,8 +274,8 @@ export const AddEditStatusForm = () => {
 								{status.name}
 							</button>
 							<div className = "tw-flex tw-flex-col tw-items-center">
-								<IconButton disabled = {index === 0} onClick={() => updateStatusOrder(status.id, findNextClosestOrder(status.id, status.order, false))}><ArrowUp className = "tw-w-6 tw-h-6"/></IconButton>
-								<IconButton disabled = {index === statusData.length-1} onClick={() => updateStatusOrder(status.id, findNextClosestOrder(status.id, status.order, true))}><ArrowDown className = "tw-w-6 tw-h-6"/></IconButton>
+								<IconButton disabled = {index === 0} onClick={() => updateStatusOrder(status.id, findNextClosestOrder(status.id, status.order, false))}><IconArrowUp className = "tw-w-6 tw-h-6"/></IconButton>
+								<IconButton disabled = {index === statusData.length-1} onClick={() => updateStatusOrder(status.id, findNextClosestOrder(status.id, status.order, true))}><IconArrowDown className = "tw-w-6 tw-h-6"/></IconButton>
 							</div>
 						</div>
 						{

--- a/client/src/components/forms/RegisterUserForm.tsx
+++ b/client/src/components/forms/RegisterUserForm.tsx
@@ -4,6 +4,8 @@ import { useNavigate, Link } from "react-router-dom"
 import { useForm, Resolver, Controller } from "react-hook-form"
 import { useUserRegisterMutation } from "../../services/public/register" 
 import { FaEye, FaEyeSlash } from "react-icons/fa"
+import { IconEye } from "../../components/icons/IconEye"
+import { IconEyeSlash } from "../../components/icons/IconEyeSlash"
 import { v4 as uuidv4 } from "uuid" 
 import { LOGIN } from "../../helpers/routes"
 import "../../styles/register.css" 
@@ -176,8 +178,8 @@ export const RegisterUserForm = ({isOrgRegister, onSubmit: propSubmit, user}: Pr
 							/>
 							{
 								!showPassword ? 
-								<FaEye className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4" onClick={() => setShowPassword(!showPassword)}/> : 
-								<FaEyeSlash className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4" onClick={() => setShowPassword(!showPassword)}/>
+								<button onClick={() => setShowPassword(!showPassword)}><IconEye className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4"/></button> : 
+								<button onClick={() => setShowPassword(!showPassword)}><IconEyeSlash className = "hover:tw-opacity-60 tw-absolute tw-top-0 tw-right-0 tw-mt-4 tw-mr-4"/></button>
 							}
 						</div>
 				        {errors?.confirmPassword && <small className = "--text-alert">{errors.confirmPassword.message}</small>}

--- a/client/src/components/icons/BaseIcon.tsx
+++ b/client/src/components/icons/BaseIcon.tsx
@@ -6,7 +6,7 @@ interface Props {
 	children: React.ReactNode
 }
 
-export const BaseIcon = ({color, className, children}: Props) => {
+export const BaseIcon = ({color, className, children}: Props): React.ReactNode => {
 	return (
 		<IconContext.Provider value={{color: color ?? "", className: className ?? "tw-w-4 tw-h-4"}}>
 			{children}

--- a/client/src/components/icons/IconLink.tsx
+++ b/client/src/components/icons/IconLink.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { HiOutlineLink as LinkIcon } from "react-icons/hi";
+import { BaseIcon } from "./BaseIcon"
+
+interface Props {
+	color?: string
+	className?: string
+}
+
+export const IconLink = ({color, className}: Props) => {
+	return (
+		<BaseIcon color={color} className={className}>
+			<LinkIcon/>
+		</BaseIcon>
+	)
+}

--- a/client/src/components/icons/IconShare.tsx
+++ b/client/src/components/icons/IconShare.tsx
@@ -1,0 +1,17 @@
+import { FiShare2 as ShareIcon } from "react-icons/fi";
+import React from "react"
+import { BaseIcon } from "./BaseIcon"
+
+interface Props {
+	color?: string
+	className?: string
+}
+
+export const IconShare = ({color, className}: Props) => {
+	return (
+		<BaseIcon color={color} className={className}>
+			<ShareIcon/>
+		</BaseIcon>
+	)
+}
+

--- a/client/src/components/icons/IconTree.tsx
+++ b/client/src/components/icons/IconTree.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { ImTree } from "react-icons/im";
+import { BaseIcon } from "./BaseIcon"
+
+interface Props {
+	color?: string
+	className?: string
+}
+
+export const IconTree = ({color, className}: Props) => {
+	return (
+		<BaseIcon color={color} className={className}>
+			<ImTree/>
+		</BaseIcon>
+	)
+}


### PR DESCRIPTION
Downgrade react-icons to 5.3.0
Upgrade Typescript to latest (5.8.2)
Add overrides for react scripts so it accepts Typescript 5

See below for reference:

https://github.com/facebook/create-react-app/issues/13080
https://stackoverflow.com/questions/72392225/reactnode-is-not-a-valid-jsx-element
https://github.com/react-icons/react-icons/issues/1029

Also refactored icons
