### PR TITLE
Use sql sequence for pk and fix pg errors

### DIFF
--- a/server/db/seeds/notification_types.js
+++ b/server/db/seeds/notification_types.js
@@ -6,10 +6,10 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('notification_types').del()
   await knex('notification_types').insert([
-    {id: 1, name: "Watching Ticket", template: "{{{recipient_name}}} is now watching the ticket: {{{ticket_name}}}"},
-    {id: 2, name: "Mention", template: "{{{sender_name}}} has mentioned you here: {{{ticket_name}}}"},
-    {id: 3, name: "Ticket Assigned", template: "{{{sender_name}}} has assigned you to the ticket: {{{ticket_name}}}"},
-    {id: 4, name: "Bulk Assigned", template: "{{{sender_name}}} has assigned {{{num_tickets}}} tickets to you"},
-    {id: 5, name: "Bulk Watching", template: "You are now watching {{{num_tickets}}} tickets"}
+    {name: "Watching Ticket", template: "{{{recipient_name}}} is now watching the ticket: {{{ticket_name}}}"},
+    {name: "Mention", template: "{{{sender_name}}} has mentioned you here: {{{ticket_name}}}"},
+    {name: "Ticket Assigned", template: "{{{sender_name}}} has assigned you to the ticket: {{{ticket_name}}}"},
+    {name: "Bulk Assigned", template: "{{{sender_name}}} has assigned {{{num_tickets}}} tickets to you"},
+    {name: "Bulk Watching", template: "You are now watching {{{num_tickets}}} tickets"}
   ]);
 };

--- a/server/db/seeds/organizations.js
+++ b/server/db/seeds/organizations.js
@@ -6,7 +6,7 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('organizations').del()
   return await knex('organizations').insert([
-    {id: 1, name: 'Jansen Test Company'},
-    {id: 2, name: 'Kanban Inc.'},
+    {name: 'Jansen Test Company'},
+    {name: 'Kanban Inc.'},
   ]);
 };

--- a/server/db/seeds/priorities.js
+++ b/server/db/seeds/priorities.js
@@ -6,8 +6,8 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('priorities').del()
   return await knex('priorities').insert([
-    {id: 1, name: 'High', order: 1},
-    {id: 2, name: 'Medium', order: 2},
-    {id: 3, name: 'Low', order: 3}
+    {name: 'High', order: 1},
+    {name: 'Medium', order: 2},
+    {name: 'Low', order: 3}
   ]);
 };

--- a/server/db/seeds/ticket_relationship_types.js
+++ b/server/db/seeds/ticket_relationship_types.js
@@ -6,9 +6,9 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('ticket_relationship_types').del()
   return await knex('ticket_relationship_types').insert([
-    {id: 1, name: 'Related'},
-    {id: 2, name: 'Duplicate'},
-    {id: 3, name: 'Blocker'},
-    {id: 4, name: 'Epic'}
+    {name: 'Related'},
+    {name: 'Duplicate'},
+    {name: 'Blocker'},
+    {name: 'Epic'}
   ]);
 };

--- a/server/db/seeds/ticket_types.js
+++ b/server/db/seeds/ticket_types.js
@@ -6,9 +6,9 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('ticket_types').del()
   return await knex('ticket_types').insert([
-    {id: 1, name: 'Feature'},
-    {id: 2, name: 'Modification'},
-    {id: 3, name: 'Bug'},
-    {id: 4, name: 'Epic'}
+    {name: 'Feature'},
+    {name: 'Modification'},
+    {name: 'Bug'},
+    {name: 'Epic'}
   ]);
 };

--- a/server/db/seeds/user_roles.js
+++ b/server/db/seeds/user_roles.js
@@ -6,8 +6,8 @@ exports.seed = async function(knex) {
   // Deletes ALL existing entries
   await knex('user_roles').del()
   return await knex('user_roles').insert([
-    {id: 1, name: 'USER'},
-    {id: 2, name: 'ADMIN'},
-    {id: 3, name: 'BOARD_ADMIN'},
+    {name: 'USER'},
+    {name: 'ADMIN'},
+    {name: 'BOARD_ADMIN'},
   ]);
 };

--- a/server/helpers/functions.js
+++ b/server/helpers/functions.js
@@ -195,9 +195,18 @@ const asyncHandler = fn => (req, res, next) => {
 	fn(req, res, next).catch(next)
 }
 
+/**
+ * Inserts a single record and return id
+ */
+const insertAndGetId = async (tableName, data) => {
+	const result = await db(tableName).insert(data, 'id');
+  return result[0]?.id ?? result[0];
+}
+
 
 module.exports = {
 	batchUpdate,
+	insertAndGetId,
 	getNotificationBody,
 	mapIdToRowObject,
 	mapIdToRowAggregateArray,
@@ -205,4 +214,5 @@ module.exports = {
 	parseMentions,
 	getFromNestedObject,
 	asyncHandler,
+	insertAndGetId,
 }

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -13,6 +13,8 @@ module.exports = {
     migrations: {
       directory: "./db/migrations",
     },
+    // set sql_sequence to use auto incrementing ids instead of uuid on cockroach DB
+    // https://github.com/knex/knex/issues/4953#issuecomment-1018036689
     pool: {
       afterCreate: function (conn, done) {
         conn.query('SET serial_normalization = "sql_sequence";', function (err) {

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -13,6 +13,19 @@ module.exports = {
     migrations: {
       directory: "./db/migrations",
     },
+    pool: {
+      afterCreate: function (conn, done) {
+        conn.query('SET serial_normalization = "sql_sequence";', function (err) {
+          if (err) {
+            done(err, conn);
+          } else {
+            conn.query('SET default_int_size = 4;', function (err) {
+              done(err, conn);
+            });
+          }
+        });
+      }
+    }
   },
   development: {
     client: process.env.DB_CLIENT,

--- a/server/migrate-db.js
+++ b/server/migrate-db.js
@@ -3,7 +3,7 @@
 const knex = require("knex");
 const knexFile = require("./knexfile.js");
 
-const environment = process.env.NODE_ENV || "development"
+const environment = "production"
 const db = knex(knexFile[environment])
 
 async function initTable(client) {

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -17,7 +17,7 @@ const {
 }  = require("../validation/board")
 const { handleValidationResult }  = require("../middleware/validationMiddleware")
 const db = require("../db/db")
-const { mapIdToRowAggregateArray, mapIdToRowAggregateObjArray, mapIdToRowObject } = require("../helpers/functions") 
+const { insertAndGetId, mapIdToRowAggregateArray, mapIdToRowAggregateObjArray, mapIdToRowObject } = require("../helpers/functions") 
 const { DEFAULT_PER_PAGE } = require("../constants")
 const { authenticateUserRole } = require("../middleware/userRoleMiddleware")
 
@@ -506,12 +506,12 @@ router.delete("/:boardId/status/:statusId", validateBoardStatusDelete, handleVal
 router.post("/", validateCreate, handleValidationResult, async (req, res, next) => {
 	try {
 		const body = {...req.body, organization_id: req.user.organization}
-		const id = await db("boards").insert({
+		const id = await insertAndGetId("boards", {
 			name: body.name,
 			ticket_limit: body.ticket_limit,
 			organization_id: body.organization_id
-		},["id"])
-		res.json({id: id[0], message: "Board inserted successfully!"})
+		})
+		res.json({id: id, message: "Board inserted successfully!"})
 	}	
 	catch (err) {
 		console.error(`Error while creating Board: ${err.message}`)

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -2,7 +2,7 @@ const express = require("express")
 const router = express.Router()
 const { validateCreate, validateGet, validateUpdate, validateDelete, validateBulkEdit, validateUpdateOrder } = require("../validation/status")
 const { handleValidationResult } = require("../middleware/validationMiddleware")
-const { batchUpdate } = require("../helpers/functions")
+const { insertAndGetId, batchUpdate } = require("../helpers/functions")
 const db = require("../db/db")
 
 router.get("/", async (req, res, next) => {
@@ -44,14 +44,14 @@ router.get("/:id", validateGet, handleValidationResult, async (req, res, next) =
 router.post("/", validateCreate, handleValidationResult, async (req, res, next) => {
 	try {
 		const body = {...req.body, organization_id: req.user.organization}
-		const id = await db("statuses").insert({
+		const id = await insertAndGetId("statuses", {
 			name: body.name,
 			order: body.order,
 			is_active: req.body.is_active,
 			is_completed: req.body.is_completed,
 			organization_id: body.organization_id
-		}, ["id"])
-		res.json({id: id[0], message: `Status inserted successfully!`})
+		})
+		res.json({id: id, message: `Status inserted successfully!`})
 	}	
 	catch (err){
 		console.error(`Error while inserting status: ${err.message}`)	


### PR DESCRIPTION
* Use `sql_sequence` setting when running migrations so the primary keys are in auto increment, rather than uuids
* Fix various error where the syntax for retrieving the last inserted id is different on postgres compared to mysql