### PR TITLE
set trust_proxy

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,8 @@ app.use(express.json())
 app.use(cors())
 
 // Enable trust proxy
-app.set('trust proxy', 1);
+app.set('trust proxy', 1)
+app.get('/ip', (request, response) => response.send(request.ip))
 
 app.use(
 	express.urlencoded({

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,9 @@ const api = (route, apiVersion = "") => {
 app.use(express.json())
 app.use(cors())
 
+// Enable trust proxy
+app.set('trust proxy', 1);
+
 app.use(
 	express.urlencoded({
 		extended: true	


### PR DESCRIPTION
Seeing if this can fix the error with express rate limit that's found here:
https://stackoverflow.com/questions/23413401/what-does-trust-proxy-actually-do-in-express-js-and-do-i-need-to-use-it
https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes
https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues