### PR TITLE
Overlapping avatars on boards page and initials for no profile pic

### DIFF
--- a/client/src/components/EditTicketForm.tsx
+++ b/client/src/components/EditTicketForm.tsx
@@ -22,7 +22,7 @@ import { OptionType, Mention, Ticket, TicketType, Priority, Status, UserProfile 
 import { FormValues } from "./AddTicketForm" 
 import { addToast } from "../slices/toastSlice" 
 import { v4 as uuidv4 } from "uuid"
-import { displayUser } from "../helpers/functions"
+import { displayUser, getUserInitials } from "../helpers/functions"
 import { TicketCommentForm } from "./TicketCommentForm"
 import { LinkedTicketForm } from "./LinkedTicketForm"
 import { EditTicketFormToolbar } from "./EditTicketFormToolbar" 
@@ -399,7 +399,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 								!isTicketAssigneesLoading && ticketAssignees && ticketAssignees?.length ? (
 									<button className = "tw-flex tw-gap-x-1 tw-flex-1 tw-flex-row tw-items-center" onClick={(e) => toggleFieldVisibility("assignees", true)}>
 										<div className = "tw-w-[2em] tw-shrink-0">
-											{selectFieldLoading["assignees"] ? <LoadingSpinner/> : <Avatar imageUrl={ticketAssignees?.[0]?.imageUrl} className = "tw-rounded-full tw-shrink-0"/>}
+											{selectFieldLoading["assignees"] ? <LoadingSpinner/> : <Avatar userInitials={getUserInitials(ticketAssignees?.[0])} imageUrl={ticketAssignees?.[0]?.imageUrl} className = "tw-rounded-full tw-shrink-0"/>}
 										</div>
 										<div className = "tw-flex tw-flex-1">
 											{userProfileSelect}
@@ -411,7 +411,7 @@ export const EditTicketForm = ({isModal, boardId, ticket, statusesToDisplay}: Pr
 						<RightSectionRow title={"Reporter"}>
 							<div className = "tw-flex tw-gap-x-1 tw-flex-1 tw-flex-row tw-items-center">
 								<div className = "tw-w-[2em] tw-shrink-0">
-									<Avatar imageUrl={reporter?.imageUrl} className = "tw-rounded-full tw-shrink-0"/>
+									<Avatar userInitials={getUserInitials(reporter)} imageUrl={reporter?.imageUrl} className = "tw-rounded-full tw-shrink-0"/>
 								</div>
 								<div className = "tw-ml-2.5 tw-flex tw-flex-1">{displayUser(reporter)}</div>
 							</div>

--- a/client/src/components/OverlappingRow.tsx
+++ b/client/src/components/OverlappingRow.tsx
@@ -10,7 +10,7 @@ If there are more than 4 items in a row, display the last circle
 that shows the count of (total num - 4)
 */
 type Props = {
-	imageUrls: Array<string>
+	imageUrls: Array<{imageUrl: string, name: string, initials: string}>
 	imageSize: string
 }
 
@@ -27,9 +27,9 @@ export const OverlappingRow = ({imageUrls, imageSize}: Props) => {
 		return (
 			<div className="tw-flex -tw-space-x-4 rtl:tw-space-x-reverse">
 				{
-					imageUrls.slice(0, amt).map((url: string) => {
+					imageUrls.slice(0, amt).map(({imageUrl, initials}: {imageUrl: string, initials: string}) => {
 					    return (
-					    	<Avatar imageUrl={url} size={width >= LG_BREAKPOINT ? imageSize : "s"} className = "tw-border-2 tw-border-gray-800 tw-rounded-full"/>
+					    	<Avatar userInitials={initials} imageUrl={imageUrl} size={width >= LG_BREAKPOINT ? imageSize : "s"} className = "tw-border-2 tw-border-gray-800 tw-rounded-full"/>
 					    )
 					})
 				}

--- a/client/src/components/OverlappingRow.tsx
+++ b/client/src/components/OverlappingRow.tsx
@@ -1,7 +1,8 @@
 import React, {useState} from "react"
 import { CgProfile } from "react-icons/cg";
-import "../styles/overlapping-row.css"
 import { Avatar } from "./page-elements/Avatar"
+import { LG_BREAKPOINT, AVATAR_SIZES } from "../helpers/constants"
+import { useScreenSize } from "../hooks/useScreenSize"
 
 /* 
 Create a row of overlapping icons 
@@ -10,46 +11,35 @@ that shows the count of (total num - 4)
 */
 type Props = {
 	imageUrls: Array<string>
+	imageSize: string
 }
 
-export const OverlappingRow = ({imageUrls}: Props) => {
-	const overlappingFactor = 22
+export const OverlappingRow = ({imageUrls, imageSize}: Props) => {
+	const { width, height } = useScreenSize()
+	const size = `${imageSize && imageSize in AVATAR_SIZES && width >= LG_BREAKPOINT ? AVATAR_SIZES[imageSize] : AVATAR_SIZES.s}` 
 	const total = imageUrls.length
 	const createElements = (num: number) => {
-		let elements = []
+		let amt = total <= 4 ? total : 4
 		let remainder = 0
 		if (num >= 4){
 			remainder = num - 4
 		}
-		let amt = total <= 4 ? total : 4 
-		let curLeft = 0
-		let zIndex = total 
-		for (let i = 0; i < amt; ++i){
-			curLeft += overlappingFactor 
-			zIndex -= 1 
-			const style = {
-				"position": "absolute",
-				"top": "0",
-				"left": `${curLeft}px`,
-				"zIndex": zIndex,
-			} as React.CSSProperties
-			elements.push(
-			<div key={curLeft} style={style} className = "circle">
-				<Avatar imageUrl = {imageUrls[i]} className = "tw-rounded-full"/>
+		return (
+			<div className="tw-flex -tw-space-x-4 rtl:tw-space-x-reverse">
+				{
+					imageUrls.slice(0, amt).map((url: string) => {
+					    return (
+					    	<Avatar imageUrl={url} size={width >= LG_BREAKPOINT ? imageSize : "s"} className = "tw-border-2 tw-border-gray-800 tw-rounded-full"/>
+					    )
+					})
+				}
+				{
+					remainder > 0 ?
+				    <div className={`${size} tw-flex tw-items-center tw-justify-center tw-text-xs tw-font-medium tw-text-white tw-bg-gray-700 tw-border-2 tw-border-white tw-rounded-full dark:tw-border-gray-800`}>+{remainder}</div>
+				    : null
+				}
 			</div>
-			)
-		}
-		if (remainder > 0){
-			elements.push(
-			<div key={`container_${curLeft}`} style = {{position: "absolute", top: 0, left: `${curLeft + 30}px`}} className = "remainder-circle">
-				<span className = "__count">+{remainder}</span>	
-			</div>)
-		}
-		return elements
+		)
 	}
-	return (
-		<div className = "overlapping-container">
-			{createElements(total)}		
-		</div>
-	)
+	return createElements(total)
 }

--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -6,7 +6,7 @@ import { IconClose } from "./icons/IconClose";
 import { Link, useLocation } from 'react-router-dom';
 import { CgProfile } from "react-icons/cg";
 import { LoadingSpinner } from "./LoadingSpinner" 
-import { displayUser } from "../helpers/functions"
+import { displayUser, getUserInitials } from "../helpers/functions"
 import { Logo } from "../components/page-elements/Logo"
 import { useGetUserRolesQuery } from "../services/private/userRole"
 import { useGetUserProfileQuery } from "../services/private/userProfile"
@@ -92,7 +92,7 @@ export const SideBar = () => {
 						<GradientContainer className = "tw-h-20 sidebar__bottom-bar">
 							<div className = "sidebar__bottom-bar__content">
 								<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center">
-									<Avatar imageUrl={userProfile?.imageUrl} className = "tw-rounded-full"/>
+									<Avatar userInitials={getUserInitials(userProfile)} imageUrl={userProfile?.imageUrl} className = "tw-rounded-full"/>
 									<div>
 										<span>{displayUser(userProfile)}</span>
 										<small>{userProfile?.organizationName}</small>

--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -20,7 +20,7 @@ export const Table = ({config, data, itemIds, tableKey: tKey, hideCheckAllBox}: 
 	// we cannot show the checkboxes and the action buttons
 	const showCheckboxes = config.bulkEdit?.isEnabled && config.bulkEdit?.filter && allIds.length > 0
 	return (
-		<div className = "tw-max-w-4xl tw-overflow-x-auto">
+		<div className = "tw-max-w-6xl tw-overflow-x-auto">
 			<table className = "tw-min-w-full tw-w-max">
 				<thead>
 					<tr>

--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -20,8 +20,8 @@ export const Table = ({config, data, itemIds, tableKey: tKey, hideCheckAllBox}: 
 	// we cannot show the checkboxes and the action buttons
 	const showCheckboxes = config.bulkEdit?.isEnabled && config.bulkEdit?.filter && allIds.length > 0
 	return (
-		<div style = {{maxWidth: `${LG_BREAKPOINT}px`}} className = "tw-overflow-x-auto lg:tw-max-w-full lg:overflow-hidden">
-			<table>
+		<div className = "tw-max-w-4xl tw-overflow-x-auto">
+			<table className = "tw-min-w-full tw-w-max">
 				<thead>
 					<tr>
 						{showCheckboxes ? (

--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -84,7 +84,7 @@ export const Table = ({config, data, itemIds, tableKey: tKey, hideCheckAllBox}: 
 											const {component: Component, props} = config.renderers[headerKey](row[headerKey])
 											return (
 												<td key = {`${tableKey}-${row.id}-${headerKey}`}>
-													<div className = "tw-flex tw-justify-center">
+													<div className = "tw-flex">
 														<Component {...props}/>
 													</div>
 												</td>

--- a/client/src/components/Ticket.tsx
+++ b/client/src/components/Ticket.tsx
@@ -26,6 +26,7 @@ import { BsThreeDots as MenuIcon } from "react-icons/bs";
 import { EditTicketFormMenuDropdown } from "./dropdowns/EditTicketFormMenuDropdown"
 import { useClickOutside } from "../hooks/useClickOutside" 
 import { useScreenSize } from "../hooks/useScreenSize"
+import { getUserInitials } from "../helpers/functions"
 import { LG_BREAKPOINT } from "../helpers/constants"
 
 export const priorityIconMap: {[key: string]: ReactNode} = {
@@ -110,7 +111,7 @@ export const Ticket = ({ticket, boardId, statusesToDisplay, dropdownAlignLeft, i
 		<div className = {`tw-relative tw-w-full tw-h-full tw-flex tw-flex-col tw-items-start tw-bg-white tw-rounded-md tw-shadow-md hover:tw-bg-gray-50 tw-p-2 tw-gap-y-2`}>
 			<div className = "tw-w-full tw-flex tw-flex-row tw-justify-between tw-gap-x-1 tw-text-wrap">
 				<span className = "tw-w-4/5 tw-font-medium tw-break-words">{ticket.name}</span>
-				<Avatar imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-shrink-0 tw-mt-1 tw-rounded-full"/>
+				<Avatar userInitials={getUserInitials(data)} imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-shrink-0 tw-mt-1 tw-rounded-full"/>
 			</div>
 			<div className = "tw-flex tw-flex-row tw-gap-x-2">
 				{

--- a/client/src/components/TicketRow.tsx
+++ b/client/src/components/TicketRow.tsx
@@ -11,6 +11,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react'
 import { Avatar } from "./page-elements/Avatar"
 import { useScreenSize } from "../hooks/useScreenSize"
 import { SM_BREAKPOINT } from "../helpers/constants"
+import { getUserInitials } from "../helpers/functions"
 import { LoadingSpinner } from "./LoadingSpinner"
 
 type Props = {
@@ -50,7 +51,7 @@ export const TicketRow = ({ticket, ticketRelationshipId, showUnlink, onUnlink, b
 					: <></>}	
 				</div>
 				{width >= SM_BREAKPOINT ? 
-					(isLoading ? <CgProfile className = "tw-mt-1 tw-shrink-0 tw-w-6 tw-h-6"/> : <Avatar imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-mt-1 tw-shrink-0 tw-rounded-full"/>) 
+					(isLoading ? <CgProfile className = "tw-mt-1 tw-shrink-0 tw-w-6 tw-h-6"/> : <Avatar userInitials={getUserInitials(data)} imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-mt-1 tw-shrink-0 tw-rounded-full"/>) 
 				: null}
 				<div className = "tw-text-left tw-break-words">{status?.name}</div>
 			</div>

--- a/client/src/components/account/AccountContainer.tsx
+++ b/client/src/components/account/AccountContainer.tsx
@@ -10,7 +10,7 @@ import { IconEmail } from "../icons/IconEmail"
 import { IconGear } from "../icons/IconGear"
 import { USER_PROFILE_URL, USER_PROFILE_ORG_URL } from "../../helpers/urls"
 import { ACCOUNT, ACCOUNT_CREATE_ORG, ACCOUNT_SWITCH_ORGANIZATION, ACCOUNT_CHANGE_PASSWORD, ACCOUNT_JOIN_ORGANIZATION, ACCOUNT_NOTIFICATION_SETTINGS, NOTIFICATIONS } from "../../helpers/routes"
-import { displayUser } from "../../helpers/functions"
+import { displayUser, getUserInitials } from "../../helpers/functions"
 import { SettingsCard } from "../page-elements/SettingsCard"
 import { ProfileCard } from "../page-elements/ProfileCard"
 import { Banner } from "../page-elements/Banner"
@@ -36,7 +36,7 @@ export const AccountContainer = ({userProfile, links, uploadImage, setUploadImag
 					<>
 						<div className = "lg:tw-w-1/4 tw-flex tw-flex-col tw-gap-y-4">
 							<>
-								<ProfileCard entityId={userProfile.id} imageUploadUrl={`${USER_PROFILE_URL}/image`} invalidatesTags={["UserProfiles"]} imageUrl={userProfile?.imageUrl}>
+								<ProfileCard initials={getUserInitials(userProfile)} entityId={userProfile.id} imageUploadUrl={`${USER_PROFILE_URL}/image`} invalidatesTags={["UserProfiles"]} imageUrl={userProfile?.imageUrl}>
 									<>
 										<div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-start">
 								 			<div><IconUser className = "tw-mt-1"/></div>

--- a/client/src/components/dropdowns/AccountDropdown.tsx
+++ b/client/src/components/dropdowns/AccountDropdown.tsx
@@ -9,7 +9,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { TEMP, NOTIFICATIONS, ACCOUNT, ACCOUNT_SWITCH_ORGANIZATION } from "../../helpers/routes"
 import { SetColumnLimitModalProps } from "../secondary-modals/SetColumnLimitModal"
 import { Avatar } from "../page-elements/Avatar"
-import { displayUser } from "../../helpers/functions"
+import { getUserInitials, displayUser } from "../../helpers/functions"
 import { useNavigate } from "react-router-dom"
 import { Badge } from "../page-elements/Badge"
 import { IconBell } from "../icons/IconBell"
@@ -74,7 +74,7 @@ export const AccountDropdown = React.forwardRef<HTMLDivElement, Props>(({isTemp,
 		<Dropdown closeDropdown={closeDropdown} ref = {ref} className = "!tw-w-96">
 			<ul>
 				<li className = "tw-border-b tw-border-gray-200 tw-flex tw-flex-row tw-items-center tw-gap-x-4 tw-px-4 tw-py-2">
-					<Avatar imageUrl = {userProfile?.imageUrl} size = "m" className = "tw-rounded-full"/>
+					<Avatar userInitials={getUserInitials(userProfile)} imageUrl = {userProfile?.imageUrl} size = "m" className = "tw-rounded-full"/>
 					<div className = "tw-flex tw-flex-col">
 						<h3 className = "tw-m-0 tw-font-semibold">{displayUser(userProfile)}</h3>
 						<p className = "tw-text-gray-700">{userProfile?.email}</p>

--- a/client/src/components/dropdowns/WatchMenuDropdown.tsx
+++ b/client/src/components/dropdowns/WatchMenuDropdown.tsx
@@ -14,7 +14,7 @@ import {
 import { useAddNotificationMutation } from "../../services/private/notification"
 import { addToast } from "../../slices/toastSlice"
 import { v4 as uuidv4 } from "uuid"
-import { displayUser } from "../../helpers/functions"
+import { getUserInitials, displayUser } from "../../helpers/functions"
 import { FiPlus as PlusIcon } from "react-icons/fi";
 import { IconPlus } from "../icons/IconPlus"
 import { TICKETS } from "../../helpers/routes"
@@ -165,7 +165,7 @@ export const WatchMenuDropdown = React.forwardRef<HTMLDivElement, Props>(({isMob
 								ticketWatchers?.map((watcher) => {
 									return (
 										<div className = "tw-flex tw-flex-row tw-items-center tw-gap-x-2 tw-py-1">
-											<Avatar imageUrl={watcher.imageUrl} className = "tw-rounded-full !tw-w-6 !tw-h-6"/>
+											<Avatar userInitials={getUserInitials(watcher)} imageUrl={watcher.imageUrl} className = "tw-rounded-full !tw-w-6 !tw-h-6"/>
 											<p key = {`watcher_${watcher.id}`}>{displayUser(watcher)}
 											</p>
 										</div>

--- a/client/src/components/notifications/NotificationRow.tsx
+++ b/client/src/components/notifications/NotificationRow.tsx
@@ -8,6 +8,7 @@ import { IconButton } from "../page-elements/IconButton"
 import { useGetUserQuery } from "../../services/private/userProfile"
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { Avatar } from "../page-elements/Avatar"
+import { getUserInitials } from "../../helpers/functions"
 import { Indicator } from "../page-elements/Indicator"
 
 type Props = {
@@ -20,7 +21,7 @@ export const NotificationRow = ({notification}: Props) => {
 	return (
 		<div className = {`${!notification?.isRead ? "tw-bg-gray-50" : ""} tw-relative hover:tw-bg-gray-50 tw-p-2 tw-flex tw-flex-row tw-gap-x-2 tw-w-full tw-items-center tw-border tw-border-gray-200 tw-rounded-md tw-group`}>
 			<Indicator className = {"tw-top-0 tw-left-0 tw-ml-1 tw-mt-1 tw-bg-red-500 tw-w-2 tw-h-2"} showIndicator={!notification?.isRead}/>
-			{isFetching ? <CgProfile className = "tw-mt-1 tw-shrink-0 tw-w-6 tw-h-6"/> : <Avatar imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-mt-1 tw-shrink-0 tw-rounded-full"/>}
+			{isFetching ? <CgProfile className = "tw-mt-1 tw-shrink-0 tw-w-6 tw-h-6"/> : <Avatar userInitials={getUserInitials(data)} imageUrl={data?.imageUrl} className = "!tw-w-6 !tw-h-6 tw-mt-1 tw-shrink-0 tw-rounded-full"/>}
 			<div>
 				<p>{notification?.body}</p>
 			</div>

--- a/client/src/components/page-elements/Avatar.tsx
+++ b/client/src/components/page-elements/Avatar.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { CgProfile } from "react-icons/cg"
 import { IconBuilding } from "../icons/IconBuilding"
 import { useAppSelector } from "../../hooks/redux-hooks"
-import { AVATAR_SIZES } from "../../helpers/constants"
+import { AVATAR_FONT_SIZES, AVATAR_SIZES } from "../../helpers/constants"
 
 type Props = {
 	size?: string 
@@ -14,6 +14,8 @@ type Props = {
 
 export const Avatar = ({size="s", className, imageUrl, isOrg, userInitials}: Props) => {
 	const cName = `${size && size in AVATAR_SIZES ? AVATAR_SIZES[size] : AVATAR_SIZES.s} ${className}` 
+	const fontSize = `${size && size in AVATAR_FONT_SIZES ? AVATAR_FONT_SIZES[size] : AVATAR_FONT_SIZES.s}`
+
 	const defaultIcon = () => {
 		if (isOrg){
 			return (
@@ -22,10 +24,13 @@ export const Avatar = ({size="s", className, imageUrl, isOrg, userInitials}: Pro
 		}	
 		else {
 			return (
-				/* <CgProfile className={cName}/> */
-				<div className={`${cName} tw-relative tw-inline-flex tw-items-center tw-justify-center w-overflow-hidden tw-bg-gray-100 tw-rounded-full dark:tw-bg-gray-600`}>
-				    <span className="tw-font-medium tw-text-gray-600 dark:tw-text-gray-300">{userInitials}</span>
-				</div>
+				userInitials ? 
+				(
+					<div className={`${cName} tw-relative tw-inline-flex tw-items-center tw-justify-center w-overflow-hidden tw-bg-gray-100 tw-rounded-full dark:tw-bg-gray-600`}>
+					    <span className={`${fontSize} tw-font-medium tw-text-gray-600 dark:tw-text-gray-300`}>{userInitials}</span>
+					</div>
+				) :
+				<CgProfile className={cName}/>
 			)
 		}
 	}

--- a/client/src/components/page-elements/Avatar.tsx
+++ b/client/src/components/page-elements/Avatar.tsx
@@ -2,30 +2,30 @@ import React from "react"
 import { CgProfile } from "react-icons/cg"
 import { IconBuilding } from "../icons/IconBuilding"
 import { useAppSelector } from "../../hooks/redux-hooks"
+import { AVATAR_SIZES } from "../../helpers/constants"
 
 type Props = {
 	size?: string 
 	className?: string
 	imageUrl: string | undefined
 	isOrg?: boolean
+	userInitials?: string
 }
 
-export const Avatar = ({size="s", className, imageUrl, isOrg}: Props) => {
-	const sizes: {[k: string]: string} = {
-		"l": "tw-w-32 tw-h-32",
-		"m": "tw-w-16 tw-h-16",
-		"s": "tw-w-6 tw-h-6",
-	}
-	const cName = `${size && size in sizes ? sizes[size] : sizes.s} ${className}` 
+export const Avatar = ({size="s", className, imageUrl, isOrg, userInitials}: Props) => {
+	const cName = `${size && size in AVATAR_SIZES ? AVATAR_SIZES[size] : AVATAR_SIZES.s} ${className}` 
 	const defaultIcon = () => {
 		if (isOrg){
 			return (
-				<IconBuilding className={`${size === "s" ? "tw-w-4 tw-h-4" : sizes[size]} ${className}`}/>	
+				<IconBuilding className={`${size === "s" ? "tw-w-4 tw-h-4" : AVATAR_SIZES[size]} ${className}`}/>	
 			)
 		}	
 		else {
 			return (
-				<CgProfile className={cName}/>
+				/* <CgProfile className={cName}/> */
+				<div className={`${cName} tw-relative tw-inline-flex tw-items-center tw-justify-center w-overflow-hidden tw-bg-gray-100 tw-rounded-full dark:tw-bg-gray-600`}>
+				    <span className="tw-font-medium tw-text-gray-600 dark:tw-text-gray-300">{userInitials}</span>
+				</div>
 			)
 		}
 	}

--- a/client/src/components/page-elements/EditImageIndicator.tsx
+++ b/client/src/components/page-elements/EditImageIndicator.tsx
@@ -6,13 +6,14 @@ interface Props {
 	setUploadImage: (uploadImage: boolean) => void
 	uploadImage: boolean
 	imageUrl: string
+	initials?: string
 	isOrg?: boolean
 }
 
-export const EditImageIndicator = ({setUploadImage, uploadImage, imageUrl, isOrg}: Props) => {
+export const EditImageIndicator = ({setUploadImage, uploadImage, imageUrl, isOrg, initials=""}: Props) => {
 	return (
 		<div className = "tw-inline-block tw-rounded-full tw-relative">
-			<Avatar className = {`${imageUrl !== "" ? "tw-rounded-full" : ""}`} imageUrl={imageUrl} size="l" isOrg={isOrg}/>
+			<Avatar userInitials={initials} className = {`${imageUrl !== "" ? "tw-rounded-full" : ""}`} imageUrl={imageUrl} size="l" isOrg={isOrg}/>
 			<button onClick={() => setUploadImage(!uploadImage)} className = "hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-rounded-full tw-w-8 tw-h-8 tw-bg-gray-800 tw-absolute tw-right-0 tw-bottom-0"><IconEdit color="white"/></button>
 		</div>
 	)

--- a/client/src/components/page-elements/ProfileCard.tsx
+++ b/client/src/components/page-elements/ProfileCard.tsx
@@ -6,19 +6,20 @@ import { UploadImageForm } from "../UploadImageForm"
 interface Props {
 	entityId: number
 	imageUrl?: string
+	initials?: string
 	imageUploadUrl: string
 	invalidatesTags: Array<string>
 	children?: React.ReactNode
 	isOrg?: boolean
 }
 
-export const ProfileCard = ({entityId, imageUrl, imageUploadUrl, invalidatesTags, children, isOrg}: Props) => {
+export const ProfileCard = ({entityId, imageUrl, imageUploadUrl, invalidatesTags, children, isOrg, initials}: Props) => {
 
 	const [uploadImage, setUploadImage] = useState(false)
 	return (
 		<div className = "tw-w-full tw-p-4 tw-border tw-border-gray-300 tw-shadow tw-rounded-md tw-flex tw-flex-col tw-gap-y-2">
 			<div className = "tw-flex tw-flex-row tw-justify-center">
-				<EditImageIndicator isOrg={isOrg} setUploadImage={setUploadImage} uploadImage={uploadImage} imageUrl={imageUrl ?? ""}/>
+				<EditImageIndicator isOrg={isOrg} setUploadImage={setUploadImage} uploadImage={uploadImage} initials={initials} imageUrl={imageUrl ?? ""}/>
 			</div>
 			<div className = "tw-flex tw-flex-col tw-gap-y-2">
 				{

--- a/client/src/components/page-elements/TopNav.tsx
+++ b/client/src/components/page-elements/TopNav.tsx
@@ -4,7 +4,7 @@ import { useAppDispatch, useAppSelector } from "../../hooks/redux-hooks"
 import { logout } from "../../slices/authSlice" 
 import { LoadingSpinner } from "../LoadingSpinner"
 import { privateApi } from "../../services/private" 
-import { displayUser } from "../../helpers/functions"
+import { displayUser, getUserInitials } from "../../helpers/functions"
 import { Avatar } from "./Avatar"
 import { useClickOutside } from "../../hooks/useClickOutside" 
 import { IconContext } from "react-icons"
@@ -87,7 +87,7 @@ export const TopNav = () => {
 								e.preventDefault()
 								setShowDropdown(!showDropdown)
 							}}>
-								<Avatar imageUrl = {userProfile?.imageUrl} size = "s" className = "tw-rounded-full"/>
+								<Avatar userInitials={getUserInitials(userProfile)} imageUrl = {userProfile?.imageUrl} size = "s" className = "tw-rounded-full"/>
 								{
 									<Indicator showIndicator={polledNotifications?.data ? polledNotifications?.data.length > 0 : false} className = "tw-h-3 tw-w-3 -tw-bottom-0.5 -tw-right-0.5 tw-bg-red-500"/>
 								}

--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -165,4 +165,9 @@ export const US_STATES = [
 /* Common Tailwind CSS Classes */
 export const FADE_ANIMATION = "tw-transition tw-duration-100 tw-ease-in-out"
 
-
+export const AVATAR_SIZES: {[k: string]: string} = {
+    "l": "tw-w-32 tw-h-32",
+    "ml": "tw-w-16 tw-h-16",
+    "m": "tw-w-12 tw-h-12",
+    "s": "tw-w-6 tw-h-6",
+}

--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -171,3 +171,10 @@ export const AVATAR_SIZES: {[k: string]: string} = {
     "m": "tw-w-12 tw-h-12",
     "s": "tw-w-6 tw-h-6",
 }
+
+export const AVATAR_FONT_SIZES: {[k: string]: string} = {
+    "s": "tw-text-s",
+    "m": "tw-text-l",
+    "ml": "tw-text-l",
+    "l": "tw-text-xl",
+}

--- a/client/src/helpers/functions.ts
+++ b/client/src/helpers/functions.ts
@@ -96,12 +96,6 @@ export const sortStatusByOrder = (a: Status, b: Status) => {
 	return 0
 }
 
-export const doTicketsContainStatus = (statusId: number, tickets: Array<number>) => {
-	// const ticketsWithStatus = tickets.filter((ticket) => ticket.status.id === statusId)	
-	// return ticketsWithStatus.length > 0
-	return false
-}
-
 /**
  * @param backend error response as an object
  * @return Array of strings containing the parsed error messages
@@ -141,8 +135,16 @@ export const withUrlParams = (defaultForm: Record<string, any>, searchParams: Re
  * @param user
  * @return string containing the users' first and last name if the user exists, otherwise returns an empty string
  */
-export const displayUser = (user: Pick<UserProfile, "firstName" | "lastName"> | null | undefined) => {
+export const displayUser = (user: Pick<UserProfile, "firstName" | "lastName" | "imageUrl"> | null | undefined) => {
 	return user ? (user.firstName + " " + user.lastName) : ""
+}
+
+/**
+ * @param user
+ * @return string containing the users initials
+ */
+export const getUserInitials = (user: Pick<UserProfile, "firstName" | "lastName" | "imageUrl"> | null | undefined) => {
+	return user ? (user.firstName[0].toUpperCase() + user.lastName[0].toUpperCase()) : ""
 }
 
 /**

--- a/client/src/helpers/table-config/useBoardConfig.ts
+++ b/client/src/helpers/table-config/useBoardConfig.ts
@@ -1,7 +1,9 @@
 import { userProfileModifier, dateModifier } from "../table-modifiers/display-modifiers"
 import { useAppSelector, useAppDispatch } from "../../hooks/redux-hooks" 
 import { setModalType, toggleShowModal } from "../../slices/modalSlice" 
+import { UserProfile } from "../../types/common"
 import { setCurrentBoardId } from "../../slices/boardInfoSlice" 
+import { OverlappingRow } from "../../components/OverlappingRow"
 
 export type BoardConfigType = {
 	headers: Record<string, any>,
@@ -22,8 +24,18 @@ export const useBoardConfig = () => {
 			...(isAdminOrBoardAdmin ? {"edit": ""} : {})},
 		linkCol: "name",
 		link: (id: string) => `/boards/${id}`,
+		renderers: {
+			assignees: (userProfiles: Array<Pick<UserProfile, "firstName" | "lastName" | "imageUrl">>) => {
+				return {
+					component: OverlappingRow,
+					props: {
+						imageUrls: userProfiles.map((profile) => profile.imageUrl),
+						imageSize: "m",
+					}
+				}
+			}
+		},
 		modifiers: {
-			"assignees": { modifier: userProfileModifier, object: [] },
 			"lastModified": { modifier: dateModifier, object: [] },
 		},
 		...(isAdminOrBoardAdmin ? {editCol: {col: "edit", text: "Edit", onClick: (id: number) => {

--- a/client/src/helpers/table-config/useBoardConfig.ts
+++ b/client/src/helpers/table-config/useBoardConfig.ts
@@ -4,6 +4,7 @@ import { setModalType, toggleShowModal } from "../../slices/modalSlice"
 import { UserProfile } from "../../types/common"
 import { setCurrentBoardId } from "../../slices/boardInfoSlice" 
 import { OverlappingRow } from "../../components/OverlappingRow"
+import { displayUser, getUserInitials } from "../../helpers/functions"
 
 export type BoardConfigType = {
 	headers: Record<string, any>,
@@ -29,7 +30,7 @@ export const useBoardConfig = () => {
 				return {
 					component: OverlappingRow,
 					props: {
-						imageUrls: userProfiles.map((profile) => profile.imageUrl),
+						imageUrls: userProfiles.map((profile) => ({name: displayUser(profile), imageUrl: profile.imageUrl, initials: getUserInitials(profile)})),
 						imageSize: "m",
 					}
 				}

--- a/client/src/helpers/table-config/useUserProfileConfig.ts
+++ b/client/src/helpers/table-config/useUserProfileConfig.ts
@@ -34,13 +34,14 @@ export const useUserProfileConfig = () => {
 			"userRoleId": { modifier: userRoleModifier, lookup: userRoleLookup },
 		},
 		renderers: {
-			imageUrl: (url: string) => {
+			imageUrl: ({url, initials}: {url: string, initials: string}) => {
 				return {
 					component: Avatar,
 					props: {
 						imageUrl: url,
 						size: "m",	
 						className: "tw-rounded-full",
+						userInitials: initials,
 					}
 				}
 			}

--- a/client/src/pages/users/UsersDisplay.tsx
+++ b/client/src/pages/users/UsersDisplay.tsx
@@ -12,7 +12,7 @@ import { USERS } from "../../helpers/routes"
 import { PaginationRow } from "../../components/page-elements/PaginationRow"
 import { BulkEditToolbar } from "../../components/page-elements/BulkEditToolbar"
 import { useForm, FormProvider } from "react-hook-form"
-import { withUrlParams } from "../../helpers/functions"
+import { getUserInitials, withUrlParams } from "../../helpers/functions"
 import { SearchBar } from "../../components/SearchBar"
 import { RowContentLoading } from "../../components/page-elements/RowContentLoading"
 
@@ -79,7 +79,12 @@ const UserForm = ({filters}: UserFormProps) => {
 					</FormProvider>
 				</div>
 				{errors?.userQuery ? <small className = "--text-alert">{errors?.userQuery?.message}</small> : null}
-				<Table tableKey={"display-user"} data={userProfiles?.data} config={userProfileConfig}/>
+				<Table tableKey={"display-user"} data={userProfiles?.data.map((userProfile) => {
+					return {
+						...userProfile,
+						imageUrl: {url: userProfile.imageUrl, initials: getUserInitials(userProfile)}
+					}
+				})} config={userProfileConfig}/>
 				<div className = "tw-p-4 tw-border tw-border-gray-300">
 					<PaginationRow
 						showNumResults={true}

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -74,8 +74,8 @@ router.get("/", async (req, res, next) => {
 			.groupBy("tickets_to_users.user_id")
 			.groupBy("users.first_name")
 			.groupBy("users.last_name")
-			.select("boards.id as id", "tickets_to_users.user_id as userId", "users.first_name as firstName", "users.last_name as lastName")
-			boardAssigneesRes = mapIdToRowAggregateObjArray(boardAssignees, ["userId", "firstName", "lastName"])
+			.select("boards.id as id", "tickets_to_users.user_id as userId", "users.first_name as firstName", "users.last_name as lastName", "users.image_url as imageUrl")
+			boardAssigneesRes = mapIdToRowAggregateObjArray(boardAssignees, ["userId", "firstName", "lastName", "imageUrl"])
 		}
 
 		let numTickets;


### PR DESCRIPTION
* Refactor the overlapping component using tailwind CSS and display it on the boards page as a renderer
* Page wide refactor to show the user's initials in place of the empty avatar profile picture for users with no profile picture uploaded.

<img width="1769" height="949" alt="chrome_2Ra535fEGl" src="https://github.com/user-attachments/assets/05212157-ab4a-4082-89a1-0e99151fd1ee" />
<img width="1786" height="952" alt="chrome_KHGLeAEsxJ" src="https://github.com/user-attachments/assets/b76bc166-496e-49ee-89d9-2e4b7501192a" />
