### PR TITLE
Migrations for projects and sprints + tooltip + completed statuses bug fixes

### DIFF
--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -173,7 +173,7 @@ export const AVATAR_SIZES: {[k: string]: string} = {
 }
 
 export const AVATAR_FONT_SIZES: {[k: string]: string} = {
-    "s": "tw-text-s",
+    "s": "tw-text-xs",
     "m": "tw-text-l",
     "ml": "tw-text-l",
     "l": "tw-text-xl",

--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -168,7 +168,7 @@ export const FADE_ANIMATION = "tw-transition tw-duration-100 tw-ease-in-out"
 export const AVATAR_SIZES: {[k: string]: string} = {
     "l": "tw-w-32 tw-h-32",
     "ml": "tw-w-16 tw-h-16",
-    "m": "tw-w-12 tw-h-12",
+    "m": "tw-w-10 tw-h-10",
     "s": "tw-w-6 tw-h-6",
 }
 

--- a/client/src/pages/boards/BoardSchedule.tsx
+++ b/client/src/pages/boards/BoardSchedule.tsx
@@ -30,7 +30,7 @@ export const BoardSchedule = () => {
 	const [ ticketsGroupedByAssignee, setTicketsGroupedByAssignee ] = useState<Record<string, any>>({})
 	const { statuses } = useAppSelector((state) => state.status)
 	const { priorities } = useAppSelector((state) => state.priority)
-	const completeStatusId = statuses.find((status) => status.name === "Complete")?.id ?? 0
+	const completedStatuses = statuses.filter((status) => status.isCompleted).map((status) => status.id) ?? []
 	const { data: boardTicketData, isFetching: isBoardTicketFetching, isError: isBoardTicketError } = useGetBoardTicketsQuery(boardInfo ? {id: boardInfo.id, urlParams: {
 		// only include the filters that aren't null
 		...(Object.keys(filters).reduce((acc: Record<string, any>, key) => {
@@ -43,7 +43,7 @@ export const BoardSchedule = () => {
 			}
 			return acc	
 		}, {} as Record<string, any>)),
-		...(filters.statusId !== completeStatusId ? {"excludeStatusId": completeStatusId} : {}),
+		...(filters.statusId == null || !completedStatuses.includes(filters.statusId) ? {"excludeCompleted": true} : {}),
 		"skipPaginate": true, 
 		"includeAssignees": true, 
 		"requireDueDate": true,

--- a/client/src/slices/authSlice.ts
+++ b/client/src/slices/authSlice.ts
@@ -19,6 +19,7 @@ const authSlice = createSlice({
         logout: (state) => {
             localStorage.removeItem("token")
             localStorage.removeItem("isTemp")
+            localStorage.removeItem("tooltipVisibility")
             state.token = null
             state.isTemp = false
         },

--- a/client/src/slices/tooltipSlice.ts
+++ b/client/src/slices/tooltipSlice.ts
@@ -11,17 +11,19 @@ type TooltipState = {
 }
 
 const initialState: TooltipState = {
-    visibility: {
-        "ai-features": true,
-    }
+    visibility: localStorage.getItem("tooltipVisibility") != null ? JSON.parse(localStorage.getItem("tooltipVisibility") ?? "") : {
+        "ai-features": true
+    },
+    
 }
 
 const tooltipSlice = createSlice({
-    name: 'auth',
+    name: 'tooltip',
     initialState,
     reducers: {
         setVisibility: (state, action: PayloadAction<{tooltipKey: keyof TooltipKeys, value: boolean}>) => {
             state.visibility = {...state.visibility, [action.payload.tooltipKey]: action.payload.value}
+            localStorage.setItem("tooltipVisibility", JSON.stringify(state.visibility))
         },
     },
 })

--- a/server/db/migrations/20250820212427_create_projects_table.js
+++ b/server/db/migrations/20250820212427_create_projects_table.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+ 	return knex.schema.createTable("projects", (table) => {
+ 		table.increments("id").primary()	
+ 		table.string("name").notNullable()
+ 		table.string("image_url").nullable()
+ 		table.text("description").nullable()
+ 		table.integer("user_id").unsigned().notNullable()
+ 		table.foreign("user_id").references("users.id").onDelete("cascade")
+ 		table.integer("organization_id").unsigned().notNullable()
+ 		table.foreign("organization_id").references("organizations.id").onDelete("cascade")
+		table.timestamp('created_at').defaultTo(knex.fn.now());	
+ 		table.timestamp('updated_at').defaultTo(knex.raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
+ 	})
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+	return knex.schema.dropTableIfExists("projects") 
+};

--- a/server/db/migrations/20250820215541_create_projects_to_boards_table.js
+++ b/server/db/migrations/20250820215541_create_projects_to_boards_table.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+ 	return knex.schema.createTable("projects_to_boards", (table) => {
+ 		table.increments("id").primary()	
+ 		table.integer("project_id").unsigned().notNullable()
+ 		table.foreign("project_id").references("projects.id").onDelete("cascade")
+ 		table.integer("board_id").unsigned().notNullable()
+ 		table.foreign("board_id").references("boards.id").onDelete("cascade")
+		table.timestamp('created_at').defaultTo(knex.fn.now());	
+ 		table.timestamp('updated_at').defaultTo(knex.raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
+ 	})
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+	return knex.schema.dropTableIfExists("projects_to_boards") 
+};

--- a/server/db/migrations/20250820220213_add_sprint_fields_to_boards.js
+++ b/server/db/migrations/20250820220213_add_sprint_fields_to_boards.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+	return knex.schema.alterTable("boards", function(table){
+		table.text("description").nullable()
+		table.boolean("is_sprint").defaultTo(false)
+		table.integer("user_id").unsigned().nullable()
+		table.foreign("user_id").references("users.id").onDelete("cascade")
+		table.timestamp("start_date").nullable()
+		table.timestamp("end_date").nullable()
+	}) 
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+	return knex.schema.alterTable("boards", function(table){
+		table.dropColumn("description")
+		table.dropColumn("is_sprint")
+		table.dropColumn("start_date")
+		table.dropColumn("end_date")
+		table.dropForeign("user_id")
+		table.dropColumn("user_id")
+	}) 
+};

--- a/server/db/migrations/20250820220213_add_sprint_fields_to_boards.js
+++ b/server/db/migrations/20250820220213_add_sprint_fields_to_boards.js
@@ -5,6 +5,8 @@
 exports.up = function(knex) {
 	return knex.schema.alterTable("boards", function(table){
 		table.text("description").nullable()
+		table.text("sprint_debrief").nullable()
+		table.boolean("is_sprint_complete").defaultTo(false)
 		table.boolean("is_sprint").defaultTo(false)
 		table.integer("user_id").unsigned().nullable()
 		table.foreign("user_id").references("users.id").onDelete("cascade")
@@ -20,6 +22,8 @@ exports.up = function(knex) {
 exports.down = function(knex) {
 	return knex.schema.alterTable("boards", function(table){
 		table.dropColumn("description")
+		table.dropColumn("sprint_debrief")
+		table.dropColumn("is_sprint_complete")
 		table.dropColumn("is_sprint")
 		table.dropColumn("start_date")
 		table.dropColumn("end_date")

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -234,6 +234,8 @@ router.get("/:boardId/last-modified", validateGet, handleValidationResult, async
 router.get("/:boardId/ticket", validateGet, handleValidationResult, async (req, res, next) => {
 	try {
 		const board = await db("boards").where("id", req.params.boardId).first()
+		const completedStatuses = await db("statuses").where("is_completed", true)
+		const completedStatusIds = completedStatuses.map((status) => status.id)	
 		let tickets = db("tickets_to_boards")
 		.join("tickets", "tickets.id", "=", "tickets_to_boards.ticket_id")
 		.where("board_id", req.params.boardId)
@@ -256,8 +258,8 @@ router.get("/:boardId/ticket", validateGet, handleValidationResult, async (req, 
 			if (req.query.statusId){
 				queryBuilder.where("tickets.status_id", req.query.statusId)
 			}
-			if (req.query.excludeStatusId){
-				queryBuilder.where("tickets.status_id", "!=", req.query.excludeStatusId)
+			if (req.query.excludeCompleted){
+				queryBuilder.whereNotIn("tickets.status_id", completedStatusIds)
 			}
 			if (req.query.startDate){
 				queryBuilder.whereRaw("DATE(tickets.created_at) >= ?", [req.query.startDate])


### PR DESCRIPTION
* Added migrations for projects and sprints
* Adjusted tooltip to sync with localStorage so it will only re-display after the user logs out
* Fixed a bug where "closed" status tickets would show on the scheduler. It should now only show tickets that don't have the `is_completed` col set to `true`.