### PR TITLE
Scheduler Component Group By

### DIFF
--- a/client/src/components/boards/ScheduleContainerGroupedRows.tsx
+++ b/client/src/components/boards/ScheduleContainerGroupedRows.tsx
@@ -28,42 +28,44 @@ export const ScheduleContainerGroupedRows = ({tickets = [], viewMode, calculateT
                 !isLoading ? 
                     Object.keys(groupedTickets).map((groupById: string) => {
 						const groupByElement = groupByElements?.find((element: GroupByElement) => element.id === parseInt(groupById))
-                        return groupedTickets[groupById].map((ticket, index) => {
-                            const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
-                            const position = calculateTaskPosition(ticket)
-                            return (
-                                <div key={ticket.id} className="tw-flex tw-items-center hover:tw-bg-gray-50 tw-transition-colors">
-                                    {
-                                        index === 0 ? (
-                                            <div className="tw-w-48 tw-p-3 tw-border-r">
-                                                <div className="tw-font-medium tw-text-gray-800 tw-text-sm tw-truncate">
-                                                    {groupByElement?.name}
-                                                </div>
-                                            </div>
-                                        ) : (
-                                            <div className = "tw-w-48 tw-p-3 tw-border-r">
-                                            </div>
-                                        )
-                                    }
-                                    <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
-                                        <div
-                                            className="tw-absolute tw-h-6 tw-rounded-md tw-flex tw-items-center tw-justify-center tw-text-white tw-text-xs tw-font-medium tw-shadow-sm"
-                                            style={{
-                                                left: position.left,
-                                                width: position.width,
-                                                backgroundColor: TICKET_TYPE_COLOR_MAP[ticketType as keyof typeof TICKET_TYPE_COLOR_MAP] || '#3B82F6',
-                                                minWidth: '2px'
-                                            }}
-                                        >
-                                            {parseFloat(position.width) > 10 && (
-                                                <span className="tw-truncate tw-px-2">{ticket.name}</span>
-                                            )}
+                        return (
+                            <>
+                                <div className = "tw-flex tw-items-center">
+                                    <div className="tw-w-48 tw-p-3 tw-border-r">
+                                        <div className="tw-font-medium tw-text-gray-800 tw-text-sm tw-truncate">
+                                            {groupByElement?.name}
                                         </div>
+                                    </div> 
+                                    <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
                                     </div>
                                 </div>
-                            )
-                        })
-       
+                                {groupedTickets[groupById].map((ticket, index) => {
+                                    const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
+                                    const position = calculateTaskPosition(ticket)
+                                    return (
+                                        <div key={ticket.id} className="tw-flex tw-items-center hover:tw-bg-gray-50 tw-transition-colors">
+                                            <div className = "tw-w-48 tw-p-3 tw-border-r">
+                                            </div>
+                                            <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
+                                                <div
+                                                    className="tw-absolute tw-h-6 tw-rounded-md tw-flex tw-items-center tw-justify-center tw-text-white tw-text-xs tw-font-medium tw-shadow-sm"
+                                                    style={{
+                                                        left: position.left,
+                                                        width: position.width,
+                                                        backgroundColor: TICKET_TYPE_COLOR_MAP[ticketType as keyof typeof TICKET_TYPE_COLOR_MAP] || '#3B82F6',
+                                                        minWidth: '2px'
+                                                    }}
+                                                >
+                                                    {parseFloat(position.width) > 10 && (
+                                                        <span className="tw-truncate tw-px-2">{ticket.name}</span>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )
+                                })}
+                            </>
+                        )
                     })
                 : null
             }

--- a/client/src/components/boards/ScheduleContainerGroupedRows.tsx
+++ b/client/src/components/boards/ScheduleContainerGroupedRows.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useCallback } from "react"
+import { IconArrowDown } from "../icons/IconArrowDown"
+import { IconArrowUp } from "../icons/IconArrowUp"
 import { Ticket, ViewMode, GroupByElement } from "../../types/common"
 import { useAppSelector } from "../../hooks/redux-hooks"
 import { applyGroupModifier } from "../../helpers/groupBy"
@@ -33,7 +35,14 @@ export const ScheduleContainerGroupedRows = ({tickets = [], viewMode, calculateT
                                 <div className = "tw-flex tw-items-center">
                                     <div className="tw-w-48 tw-p-3 tw-border-r">
                                         <div className="tw-font-medium tw-text-gray-800 tw-text-sm tw-truncate">
-                                            {groupByElement?.name}
+                                            <button onClick={() => {
+                                                setCollapseArrows({...collapseArrows, [groupById]: !collapseArrows[groupById]})
+                                            }}>
+                                                <div className = "tw-flex tw-flex-row tw-gap-x-2 tw-items-center">
+                                                    {groupByElement?.name}
+                                                    {collapseArrows[groupById] ? <IconArrowUp /> : <IconArrowDown />}
+                                                </div>
+                                            </button>
                                         </div>
                                     </div> 
                                     <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
@@ -42,6 +51,9 @@ export const ScheduleContainerGroupedRows = ({tickets = [], viewMode, calculateT
                                 {groupedTickets[groupById].map((ticket, index) => {
                                     const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
                                     const position = calculateTaskPosition(ticket)
+                                    if (collapseArrows[groupById]) {
+                                        return null;
+                                    }
                                     return (
                                         <div key={ticket.id} className="tw-flex tw-items-center hover:tw-bg-gray-50 tw-transition-colors">
                                             <div className = "tw-w-48 tw-p-3 tw-border-r">

--- a/client/src/components/boards/ScheduleContainerGroupedRows.tsx
+++ b/client/src/components/boards/ScheduleContainerGroupedRows.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useCallback } from "react"
+import { Ticket, ViewMode, GroupByElement } from "../../types/common"
+import { useAppSelector } from "../../hooks/redux-hooks"
+import { applyGroupModifier } from "../../helpers/groupBy"
+import { useGetGroupByElementsQuery } from "../../services/private/groupBy"
+import { TICKET_TYPE_COLOR_MAP } from "../../helpers/constants"
+
+interface Props {
+    tickets?: Array<Ticket>
+    viewMode: ViewMode
+    calculateTaskPosition: (ticket: Ticket) => Record<string, string>
+}
+
+export const ScheduleContainerGroupedRows = ({tickets = [], viewMode, calculateTaskPosition}: Props) => {
+    const { groupBy } = useAppSelector((state) => state.board)
+    const { ticketTypes } = useAppSelector((state) => state.ticketType)
+    const groupedTickets = applyGroupModifier(groupBy, tickets)
+    /* object mapping the group by ids to boolean to denote whether the collapse arrow for that section is on/off */
+	const {data: groupByElements, isLoading, isError} = useGetGroupByElementsQuery({groupBy: groupBy, ids: Object.keys(groupedTickets)})  
+	const [collapseArrows, setCollapseArrows] = useState<Record<string, boolean>>(
+		Object.keys(groupedTickets).reduce((acc: Record<string, boolean>, key: string) => {
+		acc[key] = false
+		return acc
+	}, {}))
+    return (
+        <>
+            {
+                !isLoading ? 
+                    Object.keys(groupedTickets).map((groupById: string) => {
+						const groupByElement = groupByElements?.find((element: GroupByElement) => element.id === parseInt(groupById))
+                        return groupedTickets[groupById].map((ticket, index) => {
+                            const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
+                            const position = calculateTaskPosition(ticket)
+                            return (
+                                <div key={ticket.id} className="tw-flex tw-items-center hover:tw-bg-gray-50 tw-transition-colors">
+                                    {
+                                        index === 0 ? (
+                                            <div className="tw-w-48 tw-p-3 tw-border-r">
+                                                <div className="tw-font-medium tw-text-gray-800 tw-text-sm tw-truncate">
+                                                    {groupByElement?.name}
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <div className = "tw-w-48 tw-p-3 tw-border-r">
+                                            </div>
+                                        )
+                                    }
+                                    <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
+                                        <div
+                                            className="tw-absolute tw-h-6 tw-rounded-md tw-flex tw-items-center tw-justify-center tw-text-white tw-text-xs tw-font-medium tw-shadow-sm"
+                                            style={{
+                                                left: position.left,
+                                                width: position.width,
+                                                backgroundColor: TICKET_TYPE_COLOR_MAP[ticketType as keyof typeof TICKET_TYPE_COLOR_MAP] || '#3B82F6',
+                                                minWidth: '2px'
+                                            }}
+                                        >
+                                            {parseFloat(position.width) > 10 && (
+                                                <span className="tw-truncate tw-px-2">{ticket.name}</span>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            )
+                        })
+       
+                    })
+                : null
+            }
+        </>
+    )
+}

--- a/client/src/components/boards/ScheduleContainerGroupedRows.tsx
+++ b/client/src/components/boards/ScheduleContainerGroupedRows.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react"
 import { IconArrowDown } from "../icons/IconArrowDown"
 import { IconArrowUp } from "../icons/IconArrowUp"
-import { Ticket, ViewMode, GroupByElement } from "../../types/common"
+import { Ticket, GroupByElement } from "../../types/common"
 import { useAppSelector } from "../../hooks/redux-hooks"
 import { applyGroupModifier } from "../../helpers/groupBy"
 import { useGetGroupByElementsQuery } from "../../services/private/groupBy"
@@ -9,16 +9,15 @@ import { TICKET_TYPE_COLOR_MAP } from "../../helpers/constants"
 
 interface Props {
     tickets?: Array<Ticket>
-    viewMode: ViewMode
     calculateTaskPosition: (ticket: Ticket) => Record<string, string>
 }
 
-export const ScheduleContainerGroupedRows = ({tickets = [], viewMode, calculateTaskPosition}: Props) => {
+export const ScheduleContainerGroupedRows = ({tickets = [], calculateTaskPosition}: Props) => {
     const { groupBy } = useAppSelector((state) => state.board)
     const { ticketTypes } = useAppSelector((state) => state.ticketType)
     const groupedTickets = applyGroupModifier(groupBy, tickets)
-    /* object mapping the group by ids to boolean to denote whether the collapse arrow for that section is on/off */
 	const {data: groupByElements, isLoading, isError} = useGetGroupByElementsQuery({groupBy: groupBy, ids: Object.keys(groupedTickets)})  
+    /* object mapping the group by ids to boolean to denote whether the collapse arrow for that section is on/off */
 	const [collapseArrows, setCollapseArrows] = useState<Record<string, boolean>>(
 		Object.keys(groupedTickets).reduce((acc: Record<string, boolean>, key: string) => {
 		acc[key] = false

--- a/client/src/components/boards/ScheduleContainerRows.tsx
+++ b/client/src/components/boards/ScheduleContainerRows.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback } from "react"
+import { useAppSelector } from "../../hooks/redux-hooks"
+import { Ticket, ViewMode } from "../../types/common"
+import { applyGroupModifier } from "../../helpers/groupBy"
+import { TICKET_TYPE_COLOR_MAP } from "../../helpers/constants"
+import { isBefore, isAfter, differenceInMilliseconds } from "date-fns"
+import { useGetGroupByElementsQuery } from "../../services/private/groupBy"
+import { ScheduleContainerGroupedRows } from "./ScheduleContainerGroupedRows"
+
+interface Props {
+    tickets?: Array<Ticket>
+    viewMode: ViewMode
+    periodStart: Date,
+    periodEnd: Date
+}
+
+export const ScheduleContainerRows = ({
+    tickets = [], 
+    viewMode,
+    periodStart,
+    periodEnd,
+}: Props) => {
+    const { ticketTypes } = useAppSelector((state) => state.ticketType)
+    const { groupBy } = useAppSelector((state) => state.board)
+    // Calculate task bar position and width
+    const calculateTaskPosition = (ticket: Ticket) => {
+        const taskStart = new Date(ticket.createdAt)
+        const taskEnd = new Date(ticket.dueDate)
+        
+        // Clamp task dates to visible period
+        const visibleStart = isBefore(taskStart, periodStart) ? periodStart : taskStart
+        const visibleEnd = isAfter(taskEnd, periodEnd) ? periodEnd : taskEnd
+        
+        // Calculate time differences
+        const totalPeriodMs = differenceInMilliseconds(periodEnd, periodStart)
+        const taskStartMs = differenceInMilliseconds(visibleStart, periodStart)
+        const taskDurationMs = differenceInMilliseconds(visibleEnd, visibleStart)
+        
+        const leftPercentage = (taskStartMs / totalPeriodMs) * 100
+        const widthPercentage = (taskDurationMs / totalPeriodMs) * 100
+        
+        return {
+            left: `${Math.max(0, leftPercentage)}%`,
+            width: `${Math.min(100 - leftPercentage, widthPercentage)}%`
+        }
+    }
+
+    return (
+        <div className="tw-divide-y tw-divide-gray-100">
+        {tickets.length === 0 ? (
+            <div className="tw-p-8 tw-text-center tw-text-gray-500">
+                No tasks found for the current {viewMode} period
+            </div>
+        ) : (
+            groupBy === "NONE" ? 
+            tickets.map(ticket => {
+                const position = calculateTaskPosition(ticket)
+                const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
+                return (
+                    <div key={ticket.id} className="tw-flex tw-items-center hover:tw-bg-gray-50 tw-transition-colors">
+                        <div className="tw-w-48 tw-p-3 tw-border-r tw-border-gray-200">
+                            <div className="tw-font-medium tw-text-gray-800 tw-text-sm tw-truncate">
+                                {ticket.name}
+                            </div>
+                            <div className="tw-text-xs tw-text-gray-500">
+                                {new Date(ticket.createdAt).toLocaleDateString()} - {new Date(ticket.dueDate).toLocaleDateString()}
+                            </div>
+                        </div>
+                        <div className="tw-flex-1 tw-relative tw-h-12 tw-flex tw-items-center">
+                            <div
+                                className="tw-absolute tw-h-6 tw-rounded-md tw-flex tw-items-center tw-justify-center tw-text-white tw-text-xs tw-font-medium tw-shadow-sm"
+                                style={{
+                                    left: position.left,
+                                    width: position.width,
+                                    backgroundColor: TICKET_TYPE_COLOR_MAP[ticketType as keyof typeof TICKET_TYPE_COLOR_MAP] || '#3B82F6',
+                                    minWidth: '2px'
+                                }}
+                            >
+                                {parseFloat(position.width) > 10 && (
+                                    <span className="tw-truncate tw-px-2">{ticket.name}</span>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                )
+            }) : <ScheduleContainerGroupedRows calculateTaskPosition={calculateTaskPosition} tickets={tickets} viewMode={viewMode}/>
+        )}
+    </div>
+    )
+}

--- a/client/src/components/boards/ScheduleContainerRows.tsx
+++ b/client/src/components/boards/ScheduleContainerRows.tsx
@@ -83,7 +83,7 @@ export const ScheduleContainerRows = ({
                         </div>
                     </div>
                 )
-            }) : <ScheduleContainerGroupedRows calculateTaskPosition={calculateTaskPosition} tickets={tickets} viewMode={viewMode}/>
+            }) : <ScheduleContainerGroupedRows calculateTaskPosition={calculateTaskPosition} tickets={tickets}/>
         )}
     </div>
     )

--- a/client/src/helpers/groupBy.ts
+++ b/client/src/helpers/groupBy.ts
@@ -63,6 +63,26 @@ const groupByModifierMap: GroupByModifier = {
 }
 
 /* 
+	Based on the group by option, parses the array of tickets into the grouped version
+	Example:
+	if "TICKET_TYPE" is chosen
+	1) creates an object like so based on the group by modifier
+	{
+		ticketTypeId 1: [Array of tickets with ticketTypeId 1],
+		ticketTypeId 2: [Array of tickets with ticketTypeId 2],
+		...
+	}	
+*/
+export const applyGroupModifier = (
+	option: GroupByOptionsKey,
+	tickets: Array<Ticket>
+) => {
+	const modifier = groupByModifierMap[option as GroupByOptionsKey]
+	const grouped: Record<string, Array<Ticket>> = modifier(tickets)
+	return grouped
+}
+
+/* 
 	Based on the group by option, parses the array of tickets into the grouped version that's separated by status
 	Example:
 	if "TICKET_TYPE" is chosen
@@ -93,8 +113,7 @@ export const boardGroupBy =
 		tickets: Array<Ticket>, 
 		statusesToDisplay: Array<Status>
 	): GroupedTickets => {
-		const modifier = groupByModifierMap[option as GroupByOptionsKey]
-		const grouped: Record<string, Array<Ticket>> = modifier(tickets)
+		const grouped: Record<string, Array<Ticket>> = applyGroupModifier(option, tickets)
 		return Object.keys(grouped).reduce((acc: Record<string, Record<string, Array<number>>>, key: string) => {
 			const groupedTickets = grouped[key]
 			const groupedTicketIdsByStatusMap = statusesToDisplay.reduce((acc: Record<string, Array<number>>, status: Status) => {
@@ -107,4 +126,5 @@ export const boardGroupBy =
 			return acc
 		}, {})
 }
+
 

--- a/client/src/pages/boards/BoardSchedule.tsx
+++ b/client/src/pages/boards/BoardSchedule.tsx
@@ -5,7 +5,7 @@ import { boardApi, useGetBoardTicketsQuery } from "../../services/private/board"
 import { toggleShowModal, setModalType, setModalProps } from "../../slices/modalSlice"
 import { selectCurrentTicketId } from "../../slices/boardSlice"
 import { skipToken } from '@reduxjs/toolkit/query/react'
-import { ScheduleTask, Ticket, UserProfile, ViewMode } from "../../types/common"
+import { Ticket, UserProfile, ViewMode } from "../../types/common"
 import { startOfWeek, endOfWeek, startOfMonth, endOfMonth, format } from "date-fns"
 import { BoardFilters, setFilterButtonState, setFilters } from "../../slices/boardFilterSlice"
 import { GanttChart } from "../../components/boards/ScheduleContainer"
@@ -72,23 +72,6 @@ export const BoardSchedule = () => {
 		}))
 	}, [getCurrentPeriod])
 
-	const parseTicketsToTasks = () => {
-		if (boardTicketData){
-			return boardTicketData.data.map((ticket) => {
-				const ticketType = ticketTypes.find((ticketType) => ticketType.id === ticket.ticketTypeId)?.name ?? ""
-				const { id, name } = ticket
-				return {
-					id: id.toString(),
-					name,
-					startDate: new Date(ticket.createdAt),
-					endDate: new Date(ticket.dueDate),
-					color: ticketType !== "" ? TICKET_TYPE_COLOR_MAP[ticketType as keyof typeof TICKET_TYPE_COLOR_MAP] : ""
-				}
-			})
-		}
-		return []
-	}
-
 	return (
 		<div className = "tw-relative tw-w-full">
 			<GanttChart 
@@ -98,7 +81,7 @@ export const BoardSchedule = () => {
 				periodStart={getCurrentPeriod.start}
 				periodEnd={getCurrentPeriod.end}
 				setViewMode={setViewMode} 
-				tasks={parseTicketsToTasks()}
+				tickets={boardTicketData?.data ?? []}
 			/>
 		</div>
 	)

--- a/client/src/types/common.ts
+++ b/client/src/types/common.ts
@@ -153,14 +153,6 @@ export interface TicketActivity {
 	user?: Omit<UserProfile, "organizationId" | "userRoleId">
 }
 
-export interface ScheduleTask {
-    id: string
-    name: string
-    startDate: Date
-    endDate: Date
-    color?: string
-}
-
 export type ProfileActivity = Pick<TicketComment, "id" | "user" | "createdAt" >
 
 export interface Cell {


### PR DESCRIPTION
* Added the ability to group by (similar to boards). It uses the same redux state for group by, so the same group by option will apply over to the boards. This is in preparation for the shared filters, which will do something similar across each of the boards pages.
* Still need to adjust the styling of this component overall, especially the group by dropdown which doesn't have the right padding. As well as the group by columns themselves have borders.

https://github.com/user-attachments/assets/c8f31773-48f0-4419-9ecb-dbfb792fa09a

